### PR TITLE
change logging severity for network related calls

### DIFF
--- a/forward/forward.go
+++ b/forward/forward.go
@@ -119,7 +119,7 @@ func (f *Forwarder) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 	start := time.Now().UTC()
 	response, err := f.roundTripper.RoundTrip(reqClone)
 	if err != nil {
-		log.Errorf("Error forwarding to %v, error: %v", req.Host, err)
+		log.Debugf("Error forwarding to %v, error: %v", req.Host, err)
 		f.errHandler.ServeHTTP(w, req, err)
 		return
 	}
@@ -139,7 +139,7 @@ func (f *Forwarder) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 	if response.Body != nil {
 		_, err = io.Copy(w, response.Body)
 		if err != nil {
-			log.Error(err)
+			log.Debug(err)
 		}
 
 		response.Body.Close()

--- a/httpconnect/httpconnect.go
+++ b/httpconnect/httpconnect.go
@@ -88,22 +88,26 @@ func (f *HTTPConnectHandler) intercept(w http.ResponseWriter, req *http.Request)
 	closeConns := func() {
 		if clientConn != nil {
 			if err := clientConn.Close(); err != nil {
-				log.Errorf("Error closing the out connection: %s", err)
+				log.Debugf("Error closing the out connection: %s", err)
 			}
 		}
 		if connOut != nil {
 			if err := connOut.Close(); err != nil {
-				log.Errorf("Error closing the client connection: %s", err)
+				log.Debugf("Error closing the client connection: %s", err)
 			}
 		}
 	}
 	var closeOnce sync.Once
 	go func() {
-		_, _ = io.Copy(connOut, clientConn)
+		if _, err := io.Copy(connOut, clientConn); err != nil {
+			log.Debug(err)
+		}
 		closeOnce.Do(closeConns)
 
 	}()
-	_, _ = io.Copy(clientConn, connOut)
+	if _, err := io.Copy(clientConn, connOut); err != nil {
+		log.Debug(err)
+	}
 	closeOnce.Do(closeConns)
 
 	return


### PR DESCRIPTION
It resolves https://github.com/getlantern/http-proxy/issues/67 to not consume too many Loggly storage.

It also logs errors during `io.Copy` in `httpconnect.go`.

@uaalto mind take a look?