### PR TITLE
closes getlantern/lantern_aws#141

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,10 @@
 language: go
 go:
-- 1.5.4
+- 1.6.2
 install:
+- curl https://s3-eu-west-1.amazonaws.com/uaalto/go1.6.2_lantern_20160503_linux_amd64.tar.gz | tar -xz -C /tmp
+- rm -Rf $GOROOT
+- mv /tmp/go $GOROOT
 - go get golang.org/x/tools/cmd/cover
 - go get -v github.com/axw/gocov/gocov
 - go get -v github.com/mattn/goveralls

--- a/README.md
+++ b/README.md
@@ -4,7 +4,8 @@
 
 ## Run
 
-Go 1.5 or later is required.
+[Custom fork of Go](https://github.com/getlantern/go/tree/lantern)  is
+currently required.
 
 First get dependencies:
 

--- a/README.md
+++ b/README.md
@@ -4,8 +4,9 @@
 
 ## Run
 
-[Custom fork of Go](https://github.com/getlantern/go/tree/lantern)  is
-currently required.
+[Custom fork of Go](https://github.com/getlantern/go/tree/lantern) is
+currently required. We'll eventually switch to Go 1.7 which supports what we
+need due to [this](https://github.com/golang/go/issues/13998).
 
 First get dependencies:
 

--- a/buffers/buffers.go
+++ b/buffers/buffers.go
@@ -1,0 +1,25 @@
+// Package buffers provides shared byte buffers based on bpool
+package buffers
+
+import (
+	"github.com/oxtoacart/bpool"
+)
+
+const (
+	maxBuffers = 1000
+	bufferSize = 32768
+)
+
+var (
+	pool = bpool.NewBytePool(maxBuffers, bufferSize)
+)
+
+// Get gets a byte buffer from the pool
+func Get() []byte {
+	return pool.Get()
+}
+
+// Put returns a byte buffer to the pool
+func Put(b []byte) {
+	pool.Put(b)
+}

--- a/buffers/buffers.go
+++ b/buffers/buffers.go
@@ -6,7 +6,7 @@ import (
 )
 
 const (
-	maxBuffers = 1000
+	maxBuffers = 2500
 	bufferSize = 32768
 )
 

--- a/forward/forward.go
+++ b/forward/forward.go
@@ -72,7 +72,7 @@ func New(next http.Handler, setters ...optSetter) (*Forwarder, error) {
 	timeoutTransport := &http.Transport{
 		Dial:                dialerFunc,
 		TLSHandshakeTimeout: 10 * time.Second,
-		MaxIdleTime:         *idleTimeoutPtr, // remove idle keep-alive connections to avoid leaking memory
+		MaxIdleTime:         *idleTimeoutPtr / 2, // remove idle keep-alive connections to avoid leaking memory
 	}
 	timeoutTransport.EnforceMaxIdleTime()
 	f := &Forwarder{

--- a/forward/forward.go
+++ b/forward/forward.go
@@ -9,8 +9,10 @@ import (
 	"time"
 
 	"github.com/getlantern/golog"
-	"github.com/getlantern/http-proxy/utils"
 	"github.com/getlantern/idletiming"
+
+	"github.com/getlantern/http-proxy/buffers"
+	"github.com/getlantern/http-proxy/utils"
 )
 
 var log = golog.LoggerFor("forward")
@@ -67,10 +69,12 @@ func New(next http.Handler, setters ...optSetter) (*Forwarder, error) {
 		return idleConn, err
 	}
 
-	var timeoutTransport http.RoundTripper = &http.Transport{
+	timeoutTransport := &http.Transport{
 		Dial:                dialerFunc,
 		TLSHandshakeTimeout: 10 * time.Second,
+		MaxIdleTime:         *idleTimeoutPtr, // remove idle keep-alive connections to avoid leaking memory
 	}
+	timeoutTransport.EnforceMaxIdleTime()
 	f := &Forwarder{
 		errHandler:   utils.DefaultHandler,
 		roundTripper: timeoutTransport,
@@ -137,7 +141,9 @@ func (f *Forwarder) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 
 	// It became nil in a Co-Advisor test though the doc says it will never be nil
 	if response.Body != nil {
-		_, err = io.Copy(w, response.Body)
+		buf := buffers.Get()
+		defer buffers.Put(buf)
+		_, err = io.CopyBuffer(w, response.Body, buf)
 		if err != nil {
 			log.Debug(err)
 		}

--- a/forward/forward.go
+++ b/forward/forward.go
@@ -76,8 +76,8 @@ func New(next http.Handler, setters ...optSetter) (*Forwarder, error) {
 		TLSHandshakeTimeout: 10 * time.Second,
 		MaxIdleTime:         idleTimeout / 2, // remove idle keep-alive connections to avoid leaking memory
 	}
-	log.Debugf("MaxIdleTime: %v", timeoutTransport.MaxIdleTime)
 	timeoutTransport.EnforceMaxIdleTime()
+
 	f := &Forwarder{
 		errHandler:   utils.DefaultHandler,
 		roundTripper: timeoutTransport,

--- a/http_proxy_test.go
+++ b/http_proxy_test.go
@@ -639,10 +639,12 @@ func (m *originHandler) Close() {
 func newOriginHandler(msg string, tls bool) (string, *originHandler) {
 	m := originHandler{}
 	m.Msg(msg)
+	m.server = httptest.NewUnstartedServer(&m)
+	m.server.Config.AcceptAnyHostHeader = true
 	if tls {
-		m.server = httptest.NewTLSServer(&m)
+		m.server.StartTLS()
 	} else {
-		m.server = httptest.NewServer(&m)
+		m.server.Start()
 	}
 	log.Debugf("Started origin server at %v", m.server.URL)
 	return m.server.URL, &m

--- a/httpconnect/httpconnect.go
+++ b/httpconnect/httpconnect.go
@@ -124,7 +124,7 @@ func (f *HTTPConnectHandler) intercept(w http.ResponseWriter, req *http.Request)
 		utils.RespondBadGateway(w, req, fmt.Sprintf("Unable to hijack connection: %s", err))
 		return
 	}
-	connOutRaw, err := net.Dial("tcp", req.Host)
+	connOutRaw, err := net.DialTimeout("tcp", req.Host, 10*time.Second)
 	if err != nil {
 		return
 	}

--- a/listeners/limited.go
+++ b/listeners/limited.go
@@ -103,8 +103,8 @@ func (c *limitedConn) Close() (err error) {
 	}
 
 	// Substract 1 by adding the two-complement of -1
-	atomic.AddUint64(&c.listener.numConns, ^uint64(0))
-	log.Tracef("Closed a connection and left %v remaining", c.listener.numConns)
+	numConns := atomic.AddUint64(&c.listener.numConns, ^uint64(0))
+	log.Tracef("Closed a connection and left %v remaining", numConns)
 	return c.Conn.Close()
 }
 

--- a/server/server.go
+++ b/server/server.go
@@ -41,7 +41,9 @@ func NewServer(handler http.Handler) *Server {
 		})
 
 	server := &Server{
-		httpServer: http.Server{Handler: proxy,
+		httpServer: http.Server{
+			AcceptAnyHostHeader: true, // needed to keep Go 1.6+ from interfering with Apache mimicry
+			Handler:             proxy,
 			ConnState: func(c net.Conn, state http.ConnState) {
 				wconn, ok := c.(listeners.WrapConn)
 				if !ok {


### PR DESCRIPTION
This change fixes 3 issues that could all be contributing to memory pressure on http-proxy:

1. Time out idle connections at the http.Transport level to free up the buffers used by keep-alive connections
2. Reduce allocations by using a buffer pool when using io.Copy
3. Time out outbound dials for HTTP CONNECT (not likely to make much of a difference, but good thing to fix anyway)

@uaalto Hopefully that answers your question?