### PR TITLE
Enable Pro even if there are no users assigned, so we don't need to turn

### DIFF
--- a/profilter/profilter.go
+++ b/profilter/profilter.go
@@ -37,7 +37,6 @@ type Options struct {
 
 func New(opts *Options) (filters.Filter, error) {
 	f := &lanternProFilter{
-		enabled:   1,
 		proTokens: new(atomic.Value),
 	}
 	// atomic.Value can't be copied after Store has been called


### PR DESCRIPTION
it on with a special message from pro-server

Part also of the end-to-end tests I've been doing. Closes #103 
