### PR TITLE
Add Makefile and targets

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,4 +40,5 @@ obfs4_state.json
 
 vendor
 bin
+dist
 *.sw?

--- a/Makefile
+++ b/Makefile
@@ -1,22 +1,28 @@
 GLIDE_BIN    ?= $(shell which glide)
-GOOS         ?= linux
-GOARCH       ?= amd64
+UPX_BIN      ?= $(shell which upx)
+BUILD_DIR    ?= bin
 
 .PHONY: dist build require-glide
+
+build: require-glide
+	$(GLIDE_BIN) install && \
+	mkdir -p $(BUILD_DIR) && \
+	go build -o $(BUILD_DIR)/http-proxy-lantern github.com/getlantern/http-proxy-lantern/http-proxy && \
+	file $(BUILD_DIR)/http-proxy-lantern
 
 require-glide:
 	@if [ "$(GLIDE_BIN)" = "" ]; then \
 		echo 'Missing "glide" command. See https://github.com/Masterminds/glide' && exit 1; \
 	fi
 
-dist: require-glide
-	$(GLIDE_BIN) install && \
-	mkdir -p dist && \
-	go build -o bin/http-proxy-lantern && \
-	file bin/http-proxy-lantern
+require-upx:
+	@if [ "$(UPX_BIN)" = "" ]; then \
+		echo 'Missing "upx" command. See http://upx.sourceforge.net/' && exit 1; \
+	fi
 
-build:
-	go build -o bin/http-proxy-lantern
+dist: require-glide require-upx
+	GOOS=linux GOARCH=amd64 BUILD_DIR=dist $(MAKE) build && \
+	upx dist/http-proxy-lantern
 
 clean:
-	rm -rf dist
+	rm -rf dist bin

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ These are Lantern-specific middleware components for the HTTP Proxy in Go:
 
 ### Usage
 
-Build it with `glide install && go build`.
+Build it with `glide install && go build` or with `make build`.
 
 To get list of the command line options, please run `http-proxy-lantern -help`.
 
@@ -86,3 +86,15 @@ If you are using checkfallbacks, make sure that both the certificate and the tok
 With option `-pprofAddr=localhost:6060`, you can always access lots of debug information from http://localhost:6060/debug/pprof. Ref https://golang.org/pkg/net/http/pprof/.
 
 ***Be sure to only listen on localhost or private addresses for security reason.***
+
+## Building for distribution and deploying
+
+When building for distribution make sure you're creating a linux/amd64 binary
+and that the resulting binary is compressed with
+[upx](http://upx.sourceforge.net/).
+
+You can use the following command to do all this automatically:
+
+```
+make dist
+```


### PR DESCRIPTION
The building and deployment process is a manual process, this does the same with less effort.

Use `make build` to create a local binary in `bin/` and use `make dist` to create a compressed linux/amd64 binary in `dist`.
