### PR TITLE
Added ability to set DiffServ TOS

### DIFF
--- a/diffserv/diffserv.go
+++ b/diffserv/diffserv.go
@@ -1,0 +1,45 @@
+// Package diffserv provides a listener that adds diffserv TOS (a.k.a. QOS)
+// headers. For good descriptions of available TOS values, see
+// https://www.tucny.com/Home/dscp-tos.
+package diffserv
+
+import (
+	"github.com/getlantern/golog"
+	"golang.org/x/net/ipv4"
+	"net"
+)
+
+var (
+	log = golog.LoggerFor("diffserv")
+)
+
+// Wrap wraps the given Listener into a Listener that applies the specified tos
+// to all connections.
+func Wrap(l net.Listener, tos int) net.Listener {
+	return &diffservListener{l, tos}
+}
+
+type diffservListener struct {
+	wrapped net.Listener
+	tos     int
+}
+
+func (l *diffservListener) Accept() (net.Conn, error) {
+	conn, err := l.wrapped.Accept()
+	if err != nil {
+		return conn, err
+	}
+	tosErr := ipv4.NewConn(conn).SetTOS(l.tos)
+	if tosErr != nil {
+		log.Errorf("Unable to set TOS to %d: %v", l.tos, tosErr)
+	}
+	return conn, nil
+}
+
+func (l *diffservListener) Addr() net.Addr {
+	return l.wrapped.Addr()
+}
+
+func (l *diffservListener) Close() error {
+	return l.wrapped.Close()
+}

--- a/http-proxy/main.go
+++ b/http-proxy/main.go
@@ -53,6 +53,7 @@ var (
 	obfs4Dir                     = flag.String("obfs4-dir", ".", "Directory where obfs4 can store its files")
 	bench                        = flag.Bool("bench", false, "Set this flag to set up proxy as a benchmarking proxy. This automatically puts the proxy into tls mode and disables auth token authentication.")
 	fasttrackDomains             = flag.String("fasttrackdomains", "", "Whitelisted domains, such as the config server, pro server, etc, that should not count towards the bandwidth cap or be throttled, separated by comma")
+	tos                          = flag.Int("tos", 0xB8, "Specify a diffserv TOS to prioritize traffic. Defaults to 0xB8 (equivalent to DSCP EF)")
 )
 
 func init() {
@@ -117,6 +118,7 @@ func main() {
 		Obfs4Dir:                     *obfs4Dir,
 		Benchmark:                    *bench,
 		FasttrackDomains:             *fasttrackDomains,
+		DiffServTOS:                  *tos,
 	}
 
 	p.ListenAndServe()

--- a/http_proxy.go
+++ b/http_proxy.go
@@ -31,6 +31,7 @@ import (
 	"github.com/getlantern/http-proxy-lantern/common"
 	"github.com/getlantern/http-proxy-lantern/configserverfilter"
 	"github.com/getlantern/http-proxy-lantern/devicefilter"
+	"github.com/getlantern/http-proxy-lantern/diffserv"
 	"github.com/getlantern/http-proxy-lantern/kcplistener"
 	lanternlisteners "github.com/getlantern/http-proxy-lantern/listeners"
 	"github.com/getlantern/http-proxy-lantern/mimic"
@@ -308,7 +309,7 @@ func (p *Proxy) ListenAndServe() error {
 	}
 
 	if p.Obfs4Addr != "" {
-		l, listenErr := net.Listen("tcp", p.Obfs4Addr)
+		l, listenErr := p.listenTCP(p.Obfs4Addr)
 		if listenErr != nil {
 			log.Fatalf("Unable to listen with obfs4: %v", listenErr)
 		}
@@ -323,7 +324,7 @@ func (p *Proxy) ListenAndServe() error {
 		serveOBFS4(l)
 	}
 
-	l, err := net.Listen("tcp", p.Addr)
+	l, err := p.listenTCP(p.Addr)
 	if err != nil {
 		return fmt.Errorf("Unable to listen HTTP: %v", err)
 	}
@@ -338,6 +339,18 @@ func (p *Proxy) ListenAndServe() error {
 		log.Errorf("Error serving HTTP(S): %v", err)
 	}
 	return err
+}
+
+func (p *Proxy) listenTCP(addr string) (net.Listener, error) {
+	l, err := net.Listen("tcp", addr)
+	if err != nil {
+		return nil, err
+	}
+	if p.DiffServTOS > 0 {
+		log.Debugf("Setting diffserv TOS to %d", p.DiffServTOS)
+		l = diffserv.Wrap(l, p.DiffServTOS)
+	}
+	return l, nil
 }
 
 func portsFromCSV(csv string) ([]int, error) {


### PR DESCRIPTION
Depends on getlantern/http-proxy/pull/100

I tested this by inspecting packets from the server using WireShark and confirming that I see the TOS like this:

![image](https://cloud.githubusercontent.com/assets/5000654/22359432/b59dca40-e40c-11e6-85be-942d0702b287.png)

I also did some benchmarking using dcprobe and I don't see any significant difference in performance between using this and not, but it's configurable so we might as well put it out there and see if it helps anyone and if it doesn't, we just turn it off.