### PR TITLE
still allow proxy to start if redis is down

### DIFF
--- a/http-proxy/main.go
+++ b/http-proxy/main.go
@@ -24,7 +24,6 @@ var (
 	certfile                     = flag.String("cert", "", "Certificate file name")
 	cfgSvrAuthToken              = flag.String("cfgsvrauthtoken", "", "Token attached to config-server requests, not attaching if empty")
 	cfgSvrDomains                = flag.String("cfgsvrdomains", "", "Config-server domains on which to attach auth token, separated by comma")
-	enablePro                    = flag.Bool("enablepro", false, "Enable Lantern Pro support")
 	enableReports                = flag.Bool("enablereports", false, "Enable stats reporting")
 	throttlebps                  = flag.Uint64("throttlebps", 0, "If > 0, enables throttling at the given bps (needs stats reporting enabled)")
 	throttlethreshold            = flag.Uint64("throttlethreshold", 0, "If > 0, throttling will be activated at the given threshold (in bytes) in all connections of the throttled device")
@@ -92,7 +91,6 @@ func main() {
 		CertFile:                     *certfile,
 		CfgSvrAuthToken:              *cfgSvrAuthToken,
 		CfgSvrDomains:                *cfgSvrDomains,
-		EnablePro:                    *enablePro,
 		EnableReports:                *enableReports,
 		ThrottleBPS:                  *throttlebps,
 		ThrottleThreshold:            *throttlethreshold,


### PR DESCRIPTION
This addresses https://github.com/getlantern/lantern-internal/issues/667

This is less than ideal because it means the proxy will run indefinitely without bandwidth tracking, for example, so all proxies will effectively allow users to be pro. But at least Lantern will keep functioning if redis is out for extended periods. We just have to remember to restart all proxies after a redis failure however to get bandwidth tracking back.