### PR TITLE
Using special DeviceID for getlantern/lantern#851

### DIFF
--- a/devicefilter/devicefilter.go
+++ b/devicefilter/devicefilter.go
@@ -69,10 +69,10 @@ func (f *deviceFilterPre) Apply(w http.ResponseWriter, req *http.Request, next f
 
 	lanternDeviceID := req.Header.Get(common.DeviceIdHeader)
 
-	if lanternDeviceID == "" {
+	if lanternDeviceID == "~~~~~~" {
 		// DO NOT REMOVE THIS, AS IT IS REQUIRED FOR CHECK FALLBACKS TO WORK
 		// AND THEREFORE FOR PROXY LAUNCHING TO WORK!!!
-		log.Debugf("No %s header found from %s for request to %v. Closing.",
+		log.Debugf("Special %s header found from %s for request to %v. Not throttling.",
 			common.DeviceIdHeader, req.RemoteAddr, req.Host)
 	} else {
 		if f.throttleAfterBytes > 0 {


### PR DESCRIPTION
Redid this because we need to wait for 3.7.0 to be widely deployed (see https://github.com/getlantern/lantern-internal/issues/691) before we do this.