### PR TITLE
Periodically forcing GC

### DIFF
--- a/http-proxy/main.go
+++ b/http-proxy/main.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"os"
 	"runtime"
+	"runtime/debug"
 	"time"
 
 	"github.com/vharitonsky/iniflags"
@@ -100,6 +101,8 @@ func main() {
 		log.Fatal("version check redirect URL should not empty")
 	}
 
+	go periodicallyForceGC()
+
 	p := &proxy.Proxy{
 		Addr:                    *addr,
 		CertFile:                *certfile,
@@ -140,5 +143,12 @@ func main() {
 	err = p.ListenAndServe()
 	if err != nil {
 		log.Fatal(err)
+	}
+}
+
+func periodicallyForceGC() {
+	for {
+		time.Sleep(1 * time.Minute)
+		debug.FreeOSMemory()
 	}
 }


### PR DESCRIPTION
This forces http-proxy to periodically release unneeded memory to the OS, which could help avoid memory starvation for other processes that need it (like udpgw).

I'm trying this out on `47.74.32.179` right now.