### PR TITLE
Handling panics in serving single connections

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,5 @@ http-proxy
 /bin
 /pkg
 http-proxy.raw
+
+vendor

--- a/glide.lock
+++ b/glide.lock
@@ -1,0 +1,94 @@
+hash: 0759765b1f399e51a7b615dd0f73cc23709cd695bb3b0b6bb6e2ce2de15cda66
+updated: 2018-03-28T10:18:27.1303701-05:00
+imports:
+- name: github.com/aristanetworks/goarista
+  version: 94ff7b94cb7ddd528740cfc9c062037c2bc73b2d
+  subpackages:
+  - monotime
+- name: github.com/getlantern/appdir
+  version: 659a155d06e8f3dd8b9f79d6147445897499b56b
+- name: github.com/getlantern/byteexec
+  version: 4cfb26ec74f460fda433dc06fddfbad7ddee3072
+- name: github.com/getlantern/context
+  version: 624d99b1798d7c5375ea1d3ca4c5b04d58f7c775
+- name: github.com/getlantern/elevate
+  version: c2e2e4901072d1f7e9f525426735acfab5fd9cdd
+  subpackages:
+  - bin
+- name: github.com/getlantern/ema
+  version: d906ee7c3465210c328abbe6ea0f855db9db679c
+- name: github.com/getlantern/errors
+  version: e9c0296368b736086adb20832549567064224854
+- name: github.com/getlantern/filepersist
+  version: c5f0cd24e7991579ba6f5f1bd20a1ad2c9f06cd4
+- name: github.com/getlantern/go-cache
+  version: 88b53914f4672fafe9069972c1867222ef02eea1
+  subpackages:
+  - cache
+- name: github.com/getlantern/golog
+  version: cca714f7feb5df8e455f409b549d384441ac4578
+- name: github.com/getlantern/hex
+  version: 083fba3033ad473db3dd31c9bb368473d37581a7
+- name: github.com/getlantern/hidden
+  version: d52a649ab33af200943bb599898dbdcfdbc94cb7
+- name: github.com/getlantern/idletiming
+  version: 7a71d2e71cf253f64b9610ce7aa9ddfc58aa9b2a
+- name: github.com/getlantern/keyman
+  version: f55e7280e93a8802a175e9c4beccad873f3fdf43
+  subpackages:
+  - certimporter
+- name: github.com/getlantern/lampshade
+  version: b10a301ad56e92a66ef15f22c7ba921e6b84a884
+- name: github.com/getlantern/measured
+  version: 0582bf799783fba9a890459155817f1cbcf00f17
+- name: github.com/getlantern/mitm
+  version: 4ce456bae6504e6a1dc8c835cd849cba166eb3d8
+- name: github.com/getlantern/mtime
+  version: ba114e4a82b0d453c15c505073a5896453b5cbd2
+- name: github.com/getlantern/netx
+  version: 06a8a15aede91b4274bb0272108e16a4eabeca19
+- name: github.com/getlantern/ops
+  version: 37353306c90844c8e0591956f56611f46299d202
+- name: github.com/getlantern/preconn
+  version: 9d78068db81b714e7612e5d43030ee2e1ce6c49a
+- name: github.com/getlantern/proxy
+  version: bf5c9f61677cf800e1b560a10c89ea5955f74f65
+  subpackages:
+  - filters
+- name: github.com/getlantern/reconn
+  version: 7053d017511c663a3fc3b3a367b57689b1b2fd9f
+- name: github.com/getlantern/rotator
+  version: 013d4f8e36a2f6369b2435d89866056b5b74c69e
+- name: github.com/getlantern/stack
+  version: 02f928aad224fbccd50d66edd776fc9d1e9f2f2b
+- name: github.com/getlantern/tlsdefaults
+  version: cf35cfd0b1b460b031536c9846ffcd5f7811dddb
+- name: github.com/hashicorp/golang-lru
+  version: 0fb14efe8c47ae851c0034ed7a448854d3d34cf3
+  subpackages:
+  - simplelru
+- name: github.com/oxtoacart/bpool
+  version: 4e1c5567d7c2dd59fa4c7c83d34c2f3528b025d6
+- name: github.com/Yawning/chacha20
+  version: e3b1f968fc6397b51d963fee8ec8711a47bc0ce8
+- name: golang.org/x/crypto
+  version: c7dcf104e3a7a1417abc0230cb0d5240d764159d
+  subpackages:
+  - chacha20poly1305
+  - internal/chacha20
+  - poly1305
+testImports:
+- name: github.com/davecgh/go-spew
+  version: 8991bc29aa16c548c550c7ff78260e27b9ab7c73
+  subpackages:
+  - spew
+- name: github.com/getlantern/mockconn
+  version: 422a5afd4432dd82b1389333d5352da003d898a6
+- name: github.com/pmezard/go-difflib
+  version: 792786c7400a136282c1664665ae0a8db921c6c2
+  subpackages:
+  - difflib
+- name: github.com/stretchr/testify
+  version: b89eecf5ca5db6d3ba60b237ffe3df7bafb7662f
+  subpackages:
+  - assert

--- a/glide.yaml
+++ b/glide.yaml
@@ -1,0 +1,21 @@
+package: github.com/getlantern/http-proxy
+import:
+- package: github.com/getlantern/appdir
+- package: github.com/getlantern/errors
+- package: github.com/getlantern/golog
+- package: github.com/getlantern/idletiming
+- package: github.com/getlantern/lampshade
+- package: github.com/getlantern/measured
+- package: github.com/getlantern/ops
+- package: github.com/getlantern/proxy
+  subpackages:
+  - filters
+- package: github.com/getlantern/rotator
+- package: github.com/getlantern/tlsdefaults
+- package: github.com/hashicorp/golang-lru
+testImport:
+- package: github.com/getlantern/keyman
+- package: github.com/getlantern/mockconn
+- package: github.com/stretchr/testify
+  subpackages:
+  - assert


### PR DESCRIPTION
This doesn't solve the root cause of getlantern/lantern-internal#1716, but it mitigates it (and potential future problems) by recovering from panics in serving single connections. This parallels the behavior of Go's built-in http server.