### PR TITLE
Disabled blacklisting

### DIFF
--- a/http_proxy.go
+++ b/http_proxy.go
@@ -127,7 +127,8 @@ func (p *Proxy) ListenAndServe() error {
 		Dial:        dial,
 		Filter:      filterChain.Prepend(opsfilter.New(p.bm)),
 	})
-	srv.Allow = blacklist.OnConnect
+	// Temporarily disable blacklisting
+	// srv.Allow = blacklist.OnConnect
 	p.applyThrottling(srv, bwReporting)
 	srv.AddListenerWrappers(bwReporting.wrapper)
 	if p.Obfs4Addr != "" {


### PR DESCRIPTION
For getlantern/lantern-internal#1884. I've tested by manually deploying to an affected proxy. I no longer see any blacklist messages in the log. We're also following up with the user to make sure things are working better.