### PR TITLE
Return an error if client hello cipher suites are empty

### DIFF
--- a/tlslistener/tlslistener.go
+++ b/tlslistener/tlslistener.go
@@ -55,6 +55,9 @@ var standardSuites = [][]uint16{
 }
 
 func (l *tlslistener) debugClientHello(info *tls.ClientHelloInfo) (*tls.Config, error) {
+	if len(info.CipherSuites) == 0 {
+		return nil, l.log.Errorf("Client Hello has no cipher suites %v", info.Conn.RemoteAddr())
+	}
 	l.logUnusualHellos(info)
 
 	// Returning nil just tells the caller to use the standard config.

--- a/tlslistener/tlslistener_test.go
+++ b/tlslistener/tlslistener_test.go
@@ -47,4 +47,13 @@ func TestWrap(t *testing.T) {
 
 	unusual = tlsl.logUnusualHellos(info)
 	assert.False(t, unusual)
+
+	info = &tls.ClientHelloInfo{
+		CipherSuites: make([]uint16, 0),
+		Conn:         client,
+	}
+
+	config, err := tlsl.debugClientHello(info)
+	assert.Nil(t, config)
+	assert.Error(t, err)
 }


### PR DESCRIPTION
This is for the no cipher suites in common error. It should theoretically eliminate the "no cipher suites in common" error mostly from the logs, replacing it with this.

https://github.com/getlantern/lantern-internal/issues/1706

The intention is partly to verify that this actually eliminates the vast majority of cases, as that's hard to do otherwise.