### PR TITLE
Add Alipay,PaymentWall,Stripe,Adyen to fasttrack domains/better defaults

### DIFF
--- a/http-proxy/main.go
+++ b/http-proxy/main.go
@@ -26,7 +26,7 @@ var (
 
 	hostname, _ = os.Hostname()
 
-	fasttrack = "paymentwall.com,alipay.com,app-measurement.com,fastworldpay.com,firebaseremoteconfig.googleapis.com,firebaseio.com,getlantern.org,lantern.io,innovatelabs.io,getiantem.org,lantern-pro-server.herokuapp.com,lantern-pro-server-staging.herokuapp.com,optimizely.com"
+	fasttrack = "adyen.com,stripe.com,paymentwall.com,alipay.com,app-measurement.com,fastworldpay.com,firebaseremoteconfig.googleapis.com,firebaseio.com,getlantern.org,lantern.io,innovatelabs.io,getiantem.org,lantern-pro-server.herokuapp.com,lantern-pro-server-staging.herokuapp.com,optimizely.com"
 
 	addr                           = flag.String("addr", ":8080", "Address to listen")
 	certfile                       = flag.String("cert", "", "Certificate file name")


### PR DESCRIPTION
The most important change here is to add Alipay, PaymentWall, Adyen, and Stripe to our default "fasttrack"/unthrottled domains. We don't seem to actually hit PaymentWall unless proxy all is on, but we definitely hit Alipay. I have not gone through and verified all the others but would be particularly valuable for adyen since we're currently using that in production.