### PR TITLE
sends Server-Timing header with CONNECT response

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -153,7 +153,7 @@
     ".",
     "filters"
   ]
-  revision = "2e8f1a8906f7fdfc836eaabdff05e21e56e89d8e"
+  revision = "e822de39af648c8ee96450786897a50e455baa05"
 
 [[projects]]
   branch = "master"

--- a/server/server.go
+++ b/server/server.go
@@ -46,11 +46,12 @@ type Server struct {
 // New constructs a new HTTP proxy server using the given options
 func New(opts *Opts) *Server {
 	p, _ := proxy.New(&proxy.Opts{
-		IdleTimeout:        opts.IdleTimeout,
-		Dial:               opts.Dial,
-		Filter:             opts.Filter,
-		BufferSource:       buffers.Pool(),
-		OKWaitsForUpstream: true,
+		IdleTimeout:         opts.IdleTimeout,
+		Dial:                opts.Dial,
+		Filter:              opts.Filter,
+		BufferSource:        buffers.Pool(),
+		OKWaitsForUpstream:  true,
+		OKSendsServerTiming: true,
 		OnError: func(ctx filters.Context, req *http.Request, read bool, err error) *http.Response {
 			status := http.StatusBadGateway
 			if read {


### PR DESCRIPTION
For https://github.com/getlantern/lantern-internal/issues/2151, depends on https://github.com/getlantern/proxy/pull/28 (Needs to run `dep ensure` after it's merged to pass CI)