### PR TITLE
Changed header name to always set True-Client-IP for config server

### DIFF
--- a/common/headers.go
+++ b/common/headers.go
@@ -1,15 +1,19 @@
 package common
 
 const (
-	VersionHeader                       = "X-Lantern-Version"
-	DeviceIdHeader                      = "X-Lantern-Device-Id"
-	TokenHeader                         = "X-Lantern-Auth-Token"
-	PingHeader                          = "X-Lantern-Ping"
-	PingURLHeader                       = "X-Lantern-Ping-Url"
-	PingTSHeader                        = "X-Lantern-Ping-Ts"
-	ProTokenHeader                      = "X-Lantern-Pro-Token"
-	CfgSvrAuthTokenHeader               = "X-Lantern-Config-Auth-Token"
-	CfgSvrClientIPHeader                = "X-Lantern-Config-Client-IP"
+	VersionHeader         = "X-Lantern-Version"
+	DeviceIdHeader        = "X-Lantern-Device-Id"
+	TokenHeader           = "X-Lantern-Auth-Token"
+	PingHeader            = "X-Lantern-Ping"
+	PingURLHeader         = "X-Lantern-Ping-Url"
+	PingTSHeader          = "X-Lantern-Ping-Ts"
+	ProTokenHeader        = "X-Lantern-Pro-Token"
+	CfgSvrAuthTokenHeader = "X-Lantern-Config-Auth-Token"
+
+	// TrueClientIP is set to "True-Client-IP" to overwrite any spoofed
+	// "True-Client-IP" arriving from clients. Most CDNs add a True-Client-IP
+	// header before forwarding traffic.
+	TrueClientIP                        = "True-Client-IP"
 	BBRRequested                        = "X-BBR"
 	BBRAvailableBandwidthEstimateHeader = "X-BBR-ABE"
 	XBQHeader                           = "XBQ"

--- a/configserverfilter/headers.go
+++ b/configserverfilter/headers.go
@@ -69,7 +69,7 @@ func (f *ConfigServerFilter) rewrite(host string, req *http.Request) {
 		log.Errorf("Unable to split host from '%s': %s", req.RemoteAddr, err)
 		return
 	}
-	req.Header.Set(common.CfgSvrClientIPHeader, ip)
+	req.Header.Set(common.TrueClientIP, ip)
 	log.Debugf("Rewrote request from %s to %s as \"GET %s\", host %s", ip, prevHost, req.URL.String(), req.Host)
 }
 

--- a/configserverfilter/headers_test.go
+++ b/configserverfilter/headers_test.go
@@ -34,7 +34,7 @@ func TestModifyRequest(t *testing.T) {
 	assert.Equal(t, "", dummy.req.URL.Scheme, "should clear scheme")
 	assert.Equal(t, "site1.com:443", dummy.req.Host, "should use port 443")
 	assert.Equal(t, fakeToken, dummy.req.Header.Get(common.CfgSvrAuthTokenHeader), "should attach token")
-	assert.Equal(t, dummyClientIP, dummy.req.Header.Get(common.CfgSvrClientIPHeader), "should attach client ip")
+	assert.Equal(t, dummyClientIP, dummy.req.Header.Get(common.TrueClientIP), "should attach client ip")
 
 	req, _ = http.NewRequest("GET", "http://site2.org/abc.gz", nil)
 	req.RemoteAddr = dummyAddr
@@ -42,7 +42,7 @@ func TestModifyRequest(t *testing.T) {
 	assert.Equal(t, "", dummy.req.URL.Scheme, "should clear scheme")
 	assert.Equal(t, "site2.org:443", dummy.req.Host, "should use port 443")
 	assert.Equal(t, fakeToken, dummy.req.Header.Get(common.CfgSvrAuthTokenHeader), "should attach token")
-	assert.Equal(t, dummyClientIP, dummy.req.Header.Get(common.CfgSvrClientIPHeader), "should attach client ip")
+	assert.Equal(t, dummyClientIP, dummy.req.Header.Get(common.TrueClientIP), "should attach client ip")
 
 	req, _ = http.NewRequest("GET", "http://site2.org:443/abc.gz", nil)
 	req.RemoteAddr = "bad-addr"
@@ -50,7 +50,7 @@ func TestModifyRequest(t *testing.T) {
 	assert.Equal(t, "", dummy.req.URL.Scheme, "should clear scheme")
 	assert.Equal(t, "site2.org:443", dummy.req.Host, "should use port 443")
 	assert.Equal(t, fakeToken, dummy.req.Header.Get(common.CfgSvrAuthTokenHeader), "should attach token")
-	assert.Equal(t, "", dummy.req.Header.Get(common.CfgSvrClientIPHeader), "should not attach client ip if remote address is invalid")
+	assert.Equal(t, "", dummy.req.Header.Get(common.TrueClientIP), "should not attach client ip if remote address is invalid")
 
 	req, _ = http.NewRequest("GET", "http://not-config-server.org/abc.gz", nil)
 	req.RemoteAddr = dummyAddr
@@ -58,7 +58,7 @@ func TestModifyRequest(t *testing.T) {
 	assert.Equal(t, "http", dummy.req.URL.Scheme, "should not rewrite to https for other sites")
 	assert.Equal(t, "not-config-server.org", dummy.req.Host, "should not use port 443 for other sites")
 	assert.Equal(t, "", dummy.req.Header.Get(common.CfgSvrAuthTokenHeader), "should not attach token for other sites")
-	assert.Equal(t, "", dummy.req.Header.Get(common.CfgSvrClientIPHeader), "should not attach client ip for other sites")
+	assert.Equal(t, "", dummy.req.Header.Get(common.TrueClientIP), "should not attach client ip for other sites")
 }
 
 func TestInitializeNoDomains(t *testing.T) {


### PR DESCRIPTION
Minimalist change to just standardize on `True-Client-IP` everywhere, including in this case overwriting whatever the client sent.