### PR TITLE
only print the root cause when seeing error from filters

### DIFF
--- a/server/server_test.go
+++ b/server/server_test.go
@@ -146,22 +146,20 @@ func TestIdleClientConnections(t *testing.T) {
 
 	okFn := func(conn net.Conn, originURL *url.URL) {
 		time.Sleep(time.Millisecond * 900)
-		conn.Write([]byte("GET / HTTP/1.1\r\nHost: www.google.com\r\n\r\n"))
+		conn.Write([]byte("GET / HTTP/1.1\r\nHost: " + originURL.Host + "\r\n\r\n"))
 
 		var buf [400]byte
 		_, err := conn.Read(buf[:])
-
 		assert.NoError(t, err)
 		wg.Done()
 	}
 
 	idleFn := func(conn net.Conn, originURL *url.URL) {
 		time.Sleep(time.Millisecond * 1100)
-		conn.Write([]byte("GET / HTTP/1.1\r\nHost: www.google.com\r\n\r\n"))
+		conn.Write([]byte("GET / HTTP/1.1\r\nHost: " + originURL.Host + "\r\n\r\n"))
 
 		var buf [400]byte
 		_, err := conn.Read(buf[:])
-
 		assert.Error(t, err)
 	}
 


### PR DESCRIPTION
It's the quick and dirty fix for https://github.com/getlantern/lantern-internal/issues/2676. Dumping stack trace can be useful in general especially for client side debugging, but in this particular case it just creates too many noises from the chain of filters which not only distracting but also imposing performance burden.

An alternative would be rewriting the whole filters hierarchy so rather than calling `next` recursively, the filter chain calls each filter one by one within a loop, feed result from one filter to the next. I do think it's feasible and can make the code a little bit more readable, but it involves too many changes so I'd rather prefer to fiddle it seperately if we decide to do so.

Verified on a staging proxy:
```
Mar 20 03:17:09 fp-dosgp1staging-20190311-001 http-proxy[5873]: ERROR http-proxy.filters: op.go:31 lookup adasfdsaf.com on 67.207.67.3:53: no such host [client_ip=128.199.221.67 device_id= op=proxy_http origin=adasfdsaf.com origin_host=adasfdsaf.com origin_port=80 proxy_dial_timeout= root_op=http_proxy_handle]
```

@oxtoacart @myleshorton @forkner your idea?