### PR TITLE
Applying reporting on dial metrics at a lower level

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -61,7 +61,7 @@ build: require-dep require-go-version
 	github.com/getlantern/http-proxy-lantern/http-proxy && \
 	file $(BUILD_DIR)/http-proxy
 
-distnochange: require-dep require-upx require-version require-change
+distnochange: require-dep require-upx require-change
 	GOOS=linux GOARCH=amd64 BUILD_DIR=dist $(MAKE) build -o http-proxy && \
 	upx dist/http-proxy
 

--- a/http_proxy.go
+++ b/http_proxy.go
@@ -195,35 +195,9 @@ func (p *Proxy) ListenAndServe() error {
 
 	bwReporting, bordaReporter := p.configureBandwidthReporting()
 
-	reportingDial := func(ctx context.Context, isCONNECT bool, network, addr string) (net.Conn, error) {
-		op := ops.Begin("dial_origin")
-		defer op.End()
-
-		start := time.Now()
-
-		// resolve separately so that we can track the DNS resolution time
-		resolveOp := ops.Begin("resolve_origin")
-		resolvedAddr, resolveErr := net.ResolveTCPAddr(network, addr)
-		if resolveErr != nil {
-			resolveOp.FailIf(resolveErr)
-			op.FailIf(resolveErr)
-			return nil, resolveErr
-		}
-		op.Set("resolve_origin_time", bordaClient.Avg(time.Now().Sub(start).Seconds()))
-
-		conn, dialErr := dial(ctx, isCONNECT, network, resolvedAddr.String())
-		if dialErr != nil {
-			op.FailIf(dialErr)
-			return nil, dialErr
-		}
-		op.Set("dial_origin_time", bordaClient.Avg(time.Now().Sub(start).Seconds()))
-
-		return conn, nil
-	}
-
 	srv := server.New(&server.Opts{
 		IdleTimeout: p.IdleTimeout,
-		Dial:        reportingDial,
+		Dial:        dial,
 		Filter:      filterChain.Prepend(opsfilter.New(p.bm)),
 		OKDoesNotWaitForUpstream: !p.ConnectOKWaitsForUpstream,
 		OnError:                  onServerError,
@@ -435,7 +409,34 @@ func (p *Proxy) createFilterChain(bl *blacklist.Blacklist) (filters.Chain, proxy
 
 	// Google anomaly detection can be triggered very often over IPv6.
 	// Prefer IPv4 to mitigate, see issue #97
-	dialer := preferIPV4Dialer(timeoutToDialOriginSite)
+	_dialer := preferIPV4Dialer(timeoutToDialOriginSite)
+	dialer := func(ctx context.Context, network, addr string) (net.Conn, error) {
+		op := ops.Begin("dial_origin")
+		defer op.End()
+
+		start := time.Now()
+
+		// resolve separately so that we can track the DNS resolution time
+		resolveOp := ops.Begin("resolve_origin")
+		resolvedAddr, resolveErr := net.ResolveTCPAddr(network, addr)
+		if resolveErr != nil {
+			resolveOp.FailIf(resolveErr)
+			op.FailIf(resolveErr)
+			resolveOp.End()
+			return nil, resolveErr
+		}
+		op.Set("resolve_origin_time", bordaClient.Avg(time.Now().Sub(start).Seconds()))
+		resolveOp.End()
+
+		conn, dialErr := _dialer(ctx, network, resolvedAddr.String())
+		if dialErr != nil {
+			op.FailIf(dialErr)
+			return nil, dialErr
+		}
+		op.Set("dial_origin_time", bordaClient.Avg(time.Now().Sub(start).Seconds()))
+
+		return conn, nil
+	}
 	dialerForPforward := dialer
 
 	var requestRewriters []func(*http.Request)


### PR DESCRIPTION
For getlantern/lantern-internal#2713

The problem is that we were resolving domains to IPs too early, which causes [this check](https://github.com/getlantern/http-proxy-lantern/blob/master/httpsrewriter/rewriter.go#L30) to fail because it's looking for a domain but getting an IP.

The solution is to to do the resolution later.