### PR TITLE
set up tls on listener given to wss

### DIFF
--- a/http_proxy.go
+++ b/http_proxy.go
@@ -783,10 +783,12 @@ func (p *Proxy) listenWSS(addr string, bordaReporter listeners.MeasuredReportFN)
 	if err != nil {
 		return nil, errors.New("Unable to listen for wss: %v", err)
 	}
+	l, err = tlslistener.Wrap(l, p.KeyFile, p.CertFile)
+	if err != nil {
+		return nil, err
+	}
 
 	opts := &tinywss.ListenOpts{
-		CertFile: p.CertFile,
-		KeyFile:  p.KeyFile,
 		Listener: l,
 	}
 


### PR DESCRIPTION
update to reflect semantic change in the listener accepted by tinywss -- listener override must include tls if tls is desired.