### PR TITLE
Added support for persistent session ticket keys

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ BUILD_DIR    ?= bin
 GIT_REVISION := $(shell git rev-parse --short HEAD)
 CHANGE_BIN   := $(shell which github_changelog_generator)
 
-GO_VERSION := 1.12.5
+GO_VERSION := 1.12.10
 DOCKER_IMAGE_TAG := http-proxy-builder
 DOCKER_VOLS = "-v $$PWD/../../..:/src"
 

--- a/http-proxy/main.go
+++ b/http-proxy/main.go
@@ -62,9 +62,10 @@ var (
 	packetForwardAddr = flag.String("pforward-addr", "", "Address at which to listen for packet forwarding connections")
 	packetForwardIntf = flag.String("pforward-intf", "eth0", "The name of the interface to use for upstream packet forwarding connections")
 
-	keyfile  = flag.String("key", "", "Private key file name")
-	certfile = flag.String("cert", "", "Certificate file name")
-	token    = flag.String("token", "", "Lantern token")
+	keyfile              = flag.String("key", "", "Private key file name")
+	certfile             = flag.String("cert", "", "Certificate file name")
+	token                = flag.String("token", "", "Lantern token")
+	sessionTicketKeyFile = flag.String("sessionticketkey", "", "File name for storing rotating session ticket keys")
 
 	cfgSvrAuthToken           = flag.String("cfgsvrauthtoken", "", "Token attached to config-server requests, not attaching if empty")
 	connectOKWaitsForUpstream = flag.Bool("connect-ok-waits-for-upstream", false, "Set to true to wait for upstream connection before responding OK to CONNECT requests")
@@ -193,6 +194,7 @@ func main() {
 		HTTPS:                              *https,
 		IdleTimeout:                        time.Duration(*idleClose) * time.Second,
 		KeyFile:                            *keyfile,
+		SessionTicketKeyFile:               *sessionTicketKeyFile,
 		Pro:                                *pro,
 		ProxiedSitesSamplePercentage:       *proxiedSitesSamplePercentage,
 		ProxiedSitesTrackingID:             *proxiedSitesTrackingId,

--- a/http_proxy.go
+++ b/http_proxy.go
@@ -97,6 +97,7 @@ type Proxy struct {
 	HTTPS                              bool
 	IdleTimeout                        time.Duration
 	KeyFile                            string
+	SessionTicketKeyFile               string
 	Pro                                bool
 	ProxiedSitesSamplePercentage       float64
 	ProxiedSitesTrackingID             string
@@ -351,7 +352,7 @@ func (p *Proxy) wrapTLSIfNecessary(fn listenerBuilderFN) listenerBuilderFN {
 		}
 
 		if p.HTTPS {
-			l, err = tlslistener.Wrap(l, p.KeyFile, p.CertFile)
+			l, err = tlslistener.Wrap(l, p.KeyFile, p.CertFile, p.SessionTicketKeyFile)
 			if err != nil {
 				return nil, err
 			}
@@ -837,7 +838,7 @@ func (p *Proxy) listenWSS(addr string, bordaReporter listeners.MeasuredReportFN)
 	}
 
 	if p.HTTPS {
-		l, err = tlslistener.Wrap(l, p.KeyFile, p.CertFile)
+		l, err = tlslistener.Wrap(l, p.KeyFile, p.CertFile, p.SessionTicketKeyFile)
 		if err != nil {
 			return nil, err
 		}

--- a/tlslistener/sessionticket.go
+++ b/tlslistener/sessionticket.go
@@ -1,0 +1,63 @@
+package tlslistener
+
+import (
+	"crypto/rand"
+	"crypto/tls"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"time"
+)
+
+func maintainSessionTicketKey(cfg *tls.Config, sessionTicketKeyFile string) {
+	// read cached session ticket keys
+	keyBytes, err := ioutil.ReadFile(sessionTicketKeyFile)
+	if err != nil {
+		if !os.IsNotExist(err) {
+			panic(fmt.Errorf("Unable to read session ticket key file %v: %v", sessionTicketKeyFile, err))
+		}
+		keyBytes = make([]byte, 0)
+	}
+
+	// Create a new key right away
+	keyBytes = prependToSessionTicketKeys(cfg, sessionTicketKeyFile, keyBytes)
+
+	// Then rotate key every 24 hours
+	go func() {
+		for {
+			time.Sleep(24 * time.Hour)
+			keyBytes = prependToSessionTicketKeys(cfg, sessionTicketKeyFile, keyBytes)
+		}
+	}()
+}
+
+func prependToSessionTicketKeys(cfg *tls.Config, sessionTicketKeyFile string, keyBytes []byte) []byte {
+	newKey := makeSessionTicketKey()
+	keyBytes = append(newKey, keyBytes...)
+	saveSessionTicketKeys(sessionTicketKeyFile, keyBytes)
+
+	numKeys := len(keyBytes) / 32
+	keys := make([][32]byte, 0, numKeys)
+	for i := 0; i < numKeys; i++ {
+		currentKeyBytes := keyBytes[i*32:]
+		var key [32]byte
+		copy(key[:], currentKeyBytes)
+		keys = append(keys, key)
+	}
+	cfg.SetSessionTicketKeys(keys)
+
+	return keyBytes
+}
+
+func saveSessionTicketKeys(sessionTicketKeyFile string, keyBytes []byte) {
+	err := ioutil.WriteFile(sessionTicketKeyFile, keyBytes, 0644)
+	if err != nil {
+		panic(fmt.Errorf("Unable to save session ticket key bytes to %v: %v", sessionTicketKeyFile, err))
+	}
+}
+
+func makeSessionTicketKey() []byte {
+	b := make([]byte, 32)
+	rand.Read(b)
+	return b
+}

--- a/wercker.yml
+++ b/wercker.yml
@@ -3,7 +3,7 @@
 # If you want Google's container you would reference google/golang
 # Read more about containers on our dev center
 # http://devcenter.wercker.com/docs/containers/index.html
-box: golang:1.12.5
+box: golang:1.12.10
 # This is the build pipeline. Pipelines are the core of wercker
 # Read more about pipelines on our dev center
 # http://devcenter.wercker.com/docs/pipelines/index.html


### PR DESCRIPTION
For getlantern/lantern-internal#1558. We need the session ticket key to persist across restarts so that the pre-negotiated sessions that we distribute will continue to work.