### PR TITLE
Require Go 1.13.x

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ BUILD_DIR    ?= bin
 GIT_REVISION := $(shell git rev-parse --short HEAD)
 CHANGE_BIN   := $(shell which github_changelog_generator)
 
-GO_VERSION := 1.13.3
+GO_VERSION := 1.13
 
 DOCKER_IMAGE_TAG := http-proxy-builder
 DOCKER_VOLS = "-v $$PWD/../../..:/src"


### PR DESCRIPTION
The Makefile specified Go 1.13.3 and would not build with 1.13.4.  That seems wrong, so I relaxed the constraint to 1.13.x.  If we truly need 1.13.3 or greater, I can make that change instead.