### PR TITLE
Address build issues in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -80,7 +80,7 @@ docker-builder: system-checks
 # workaround to build Ubuntu binary on non-Ubuntu platforms.
 docker-distnochange: docker-builder
 	mkdir -p dist && \
-	go mod vendor && \
+	GO111MODULE=on go mod vendor && \
 	docker run -e GIT_REVISION='$(GIT_REVISION)' \
 	-v $$PWD:/src -t $(DOCKER_IMAGE_TAG) /bin/bash -c \
 	'cd /src && go build -o dist/http-proxy -ldflags="-X main.revision=$$GIT_REVISION" -mod=vendor ./http-proxy' && \


### PR DESCRIPTION
As of go v1.13, GOPRIVATE is required: https://github.com/golang/go/issues/34528

This also allows for building outside of $GOPATH.

I am quite new to go modules n' stuff, so *_please_* let me know if any of this doesn't look right