### PR TITLE
Apply idletiming to lampshade streams

### DIFF
--- a/http_proxy.go
+++ b/http_proxy.go
@@ -723,6 +723,9 @@ func (p *Proxy) listenLampshade(trackBBR bool, onListenerError func(net.Conn, er
 			wrapped = p.bm.Wrap(wrapped)
 		}
 
+		// Wrap lampshade streams with idletiming as well
+		wrapped = listeners.NewIdleConnListener(wrapped, p.IdleTimeout)
+
 		return wrapped, nil
 	}
 }


### PR DESCRIPTION
We're still seeing lampshade leaks on some servers.

The below shows that we've grown to more than 300 streams per session, which seems highly unrealistic. We show relatively streams in "closing" state, which suggests that we haven't even tried to close them. It's possible that many of these are streams that should have been timed out, so this PR adds idletiming to lampshade connections in an attempt to fix that.

```
Mar  3 16:03:42 fp-mshk1ayyysea-20200303-467 http-proxy[1616]: DEBUG lampshade: session.go:46 Sessions    Open: 58   Closing: 0   Closed: 6072   Recv Loops: 413   Send Loops: 57
Mar  3 16:03:42 fp-mshk1ayyysea-20200303-467 http-proxy[1616]: DEBUG lampshade: session.go:47 Streams     Open: 3365   Closing: 131   Closed: 246426
Mar  3 16:03:42 fp-mshk1ayyysea-20200303-467 http-proxy[1616]: DEBUG lampshade: session.go:48 Receive Buffers        Closing: 0
Mar  3 16:03:42 fp-mshk1ayyysea-20200303-467 http-proxy[1616]: DEBUG lampshade: session.go:49 Send Buffers           Closing: 131
Mar  3 16:30:16 fp-mshk1ayyysea-20200303-467 http-proxy[1616]: DEBUG lampshade: session.go:46 Sessions    Open: 14   Closing: 0   Closed: 6178   Recv Loops: 468   Send Loops: 16
Mar  3 16:30:16 fp-mshk1ayyysea-20200303-467 http-proxy[1616]: DEBUG lampshade: session.go:47 Streams     Open: 3385   Closing: 132   Closed: 246500
Mar  3 16:30:16 fp-mshk1ayyysea-20200303-467 http-proxy[1616]: DEBUG lampshade: session.go:48 Receive Buffers        Closing: 0
Mar  3 16:30:16 fp-mshk1ayyysea-20200303-467 http-proxy[1616]: DEBUG lampshade: session.go:49 Send Buffers           Closing: 132
Mar  3 17:27:09 fp-mshk1ayyysea-20200303-467 http-proxy[1616]: DEBUG lampshade: session.go:46 Sessions    Open: 10   Closing: 0   Closed: 6390   Recv Loops: 596   Send Loops: 10
Mar  3 17:27:09 fp-mshk1ayyysea-20200303-467 http-proxy[1616]: DEBUG lampshade: session.go:47 Streams     Open: 3499   Closing: 132   Closed: 246803
Mar  3 17:27:09 fp-mshk1ayyysea-20200303-467 http-proxy[1616]: DEBUG lampshade: session.go:48 Receive Buffers        Closing: 0
Mar  3 17:27:09 fp-mshk1ayyysea-20200303-467 http-proxy[1616]: DEBUG lampshade: session.go:49 Send Buffers           Closing: 132
Mar  3 17:27:20 fp-mshk1ayyysea-20200303-467 http-proxy[1616]: DEBUG lampshade: session.go:46 Sessions    Open: 9   Closing: 0   Closed: 6391   Recv Loops: 435   Send Loops: 9
Mar  3 17:27:20 fp-mshk1ayyysea-20200303-467 http-proxy[1616]: DEBUG lampshade: session.go:47 Streams     Open: 3485   Closing: 131   Closed: 246820
Mar  3 17:27:20 fp-mshk1ayyysea-20200303-467 http-proxy[1616]: DEBUG lampshade: session.go:48 Receive Buffers        Closing: 0
Mar  3 17:27:23 fp-mshk1ayyysea-20200303-467 http-proxy[1616]: DEBUG lampshade: session.go:49 Send Buffers           Closing: 131
```