### PR TITLE
Don't overwrite measured context from initial request in persistent H…

### DIFF
--- a/opsfilter/opsfilter.go
+++ b/opsfilter/opsfilter.go
@@ -61,15 +61,9 @@ func (f *opsfilter) Apply(ctx filters.Context, req *http.Request, next filters.N
 	// On persistent HTTP connections, some or all of the below may be missing on requests after the first. By only setting
 	// the values when they're available, the measured listener will preserve any values that were already included in the
 	// first request on the connection.
-	if deviceID != "" {
-		measuredCtx["deviceid"] = deviceID
-	}
-	if version != "" {
-		measuredCtx["app_version"] = version
-	}
-	if version != "" {
-		measuredCtx["app_platform"] = platform
-	}
+	f.addHeaderToContext(measuredCtx, "deviceid", deviceID)
+	f.addHeaderToContext(measuredCtx, "app_version", version)
+	f.addHeaderToContext(measuredCtx, "app_platform", platform)
 
 	clientIP, _, err := net.SplitHostPort(req.RemoteAddr)
 	if err == nil {
@@ -85,4 +79,10 @@ func (f *opsfilter) Apply(ctx filters.Context, req *http.Request, next filters.N
 	op.FailIf(nextErr)
 
 	return resp, nextCtx, nextErr
+}
+
+func (f *opsfilter) addHeaderToContext(ctx map[string]interface{}, key, headerValue string) {
+	if headerValue != "" {
+		ctx[key] = headerValue
+	}
 }


### PR DESCRIPTION
…TTP connections

On persistent HTTP connections, requests after the first are missing the platform header, which causes us to under-count traffic by platform.

This fix works by only sending available data in the control message to the measured conn. Per [this code](https://github.com/getlantern/http-proxy/blob/master/listeners/measured.go#L107), the measured conn preserves context that it already received earlier.