### PR TITLE
Include general server info like name, dc, etc with xfer stats

### DIFF
--- a/borda/borda.go
+++ b/borda/borda.go
@@ -6,6 +6,7 @@ import (
 
 	borda "github.com/getlantern/borda/client"
 	"github.com/getlantern/borda/client/rpcclient"
+	"github.com/getlantern/context"
 	"github.com/getlantern/golog"
 	"github.com/getlantern/hidden"
 	"github.com/getlantern/http-proxy/listeners"
@@ -101,13 +102,13 @@ func Enable(bordaReportInterval time.Duration, bordaSamplePercentage float64, ma
 		}
 
 		// Copy the context before modifying it
-		ctx := make(map[string]interface{}, len(_ctx))
+		ctx := make(context.Map, len(_ctx))
 		for key, value := range _ctx {
 			ctx[key] = value
 		}
 		ctx["op"] = "xfer"
 
-		reportErr := reportToBorda(vals, ctx)
+		reportErr := reportToBorda(vals, ops.AsMap(ctx, true))
 		if reportErr != nil {
 			log.Errorf("Error reporting error to borda: %v", reportErr)
 		}

--- a/go.mod
+++ b/go.mod
@@ -18,6 +18,7 @@ require (
 	github.com/getlantern/bbrconn v0.0.0-20180619163322-86cf8c16f3d0
 	github.com/getlantern/borda v0.0.0-20190809122504-668025f4c2b9
 	github.com/getlantern/cmux v0.0.0-20200120072431-136083c8edb8
+	github.com/getlantern/context v0.0.0-20190109183933-c447772a6520
 	github.com/getlantern/ema v0.0.0-20190620044903-5943d28f40e4
 	github.com/getlantern/enhttp v0.0.0-20190401024120-a974fa851e3c
 	github.com/getlantern/errors v0.0.0-20190325191628-abdb3e3e36f7


### PR DESCRIPTION
We have stats on data usage per origin, but unfortunately we don't know anything about the associated servers. This will give us that data so we can look at China-specific usage (for example).