### PR TITLE
Fix panicwrap pprof bind conflict

### DIFF
--- a/http-proxy/main.go
+++ b/http-proxy/main.go
@@ -186,7 +186,8 @@ func main() {
 				syscall.SIGHUP,
 				syscall.SIGTERM,
 				syscall.SIGQUIT,
-				os.Interrupt,
+				syscall.SIGINT,
+				syscall.SIGUSR1,
 			},
 		})
 	if panicWrapErr != nil {


### PR DESCRIPTION
Addresses the error here:
https://console.cloud.google.com/errors/CPyb-tHNwO2j3wE?time=PT1H&filter=text:4000&refresh=auto&project=lantern-http-proxy&authuser=0&organizationId=1004208199777

More context: https://wdynhnkxvsdx.slack.com/archives/C0K2M2FCN/p1588115629306200

I'm also doing a quick drive by to properly forward SIGUSR1 to the child.

Sorry the diff is so strange to look at.