### PR TITLE
Support disabling missing session ticket reaction

### DIFF
--- a/http-proxy/main.go
+++ b/http-proxy/main.go
@@ -251,6 +251,8 @@ func main() {
 		}
 		reaction = tlslistener.ReflectToSite(*missingTicketReflectSite)
 		log.Debugf("Reflecting missing session tickets to site %v", *missingTicketReflectSite)
+	case "None":
+		log.Debug("Not reacting to missing session tickets")
 	default:
 		reaction = tlslistener.AlertInternalError
 		if *requireSessionTickets {


### PR DESCRIPTION
I'm going to run a new round of proxybench tests, and proxybench doesn't support session tickets, so I need a way to turn this off on the server side.