### PR TITLE
Don't bother recording throttlecohort

### DIFF
--- a/redis/measured_reporter.go
+++ b/redis/measured_reporter.go
@@ -165,9 +165,6 @@ func submit(countryLookup geo.CountryLookup, rc *redis.Client, scriptSHA string,
 		pl.SAdd(uniqueDevicesKey, deviceID)
 		pl.ExpireAt(uniqueDevicesKey, daysFrom(nowUTC.In(time.UTC), 2)) // don't keep device IDs around in the database for too long
 
-		throttleCohortKey := "throttlecohort"
-		pl.HSet(throttleCohortKey, deviceID, throttleCohort)
-
 		_, err := pl.Exec()
 		if err != nil {
 			return err

--- a/redis/redis_test.go
+++ b/redis/redis_test.go
@@ -68,9 +68,7 @@ func TestReportPeriodically(t *testing.T) {
 	assert.Equal(t, "ir", result["countryCode"], "country code should have been remembered once set")
 
 	uniqueDevicesForToday := rc.SMembers("_devices:ir:" + time.Now().In(time.UTC).Format("2006-01-02") + ":forced").Val()
-	throttleCohort := rc.HGet("throttlecohort", deviceID).Val()
 	assert.Equal(t, []string{deviceID}, uniqueDevicesForToday)
-	assert.Equal(t, "forced", throttleCohort)
 }
 
 type fakeLookup struct{ countryCode string }


### PR DESCRIPTION
Turns out I don't need this since it's already encoded in the _devices key.

- [x] Do the tests pass? Consistently?