### PR TITLE
Added 'legacy' throttle interval for legacy clients

### DIFF
--- a/redis/measured_reporter.go
+++ b/redis/measured_reporter.go
@@ -211,7 +211,7 @@ func expirationFor(now time.Time, ttl throttle.CapInterval, timeZoneName string)
 		}
 		nextMonday := now.AddDate(0, 0, daysToNextMonday)
 		return time.Date(nextMonday.Year(), nextMonday.Month(), nextMonday.Day(), 0, 0, 0, 0, now.Location()).Add(-1 * time.Nanosecond).Unix()
-	case throttle.Monthly:
+	case throttle.Monthly, throttle.Legacy:
 		nextMonth := now.AddDate(0, 1, 0)
 		return time.Date(nextMonth.Year(), nextMonth.Month(), 1, 0, 0, 0, 0, now.Location()).Add(-1 * time.Nanosecond).Unix()
 	}

--- a/redis/redis_test.go
+++ b/redis/redis_test.go
@@ -90,7 +90,9 @@ func TestExpirationFor(t *testing.T) {
 	require.Equal(t, friday.Unix(), expirationFor(thursday, throttle.Daily, timeZone), 0)
 	require.Equal(t, friday.Unix(), expirationFor(thursday.Add(5*time.Minute), throttle.Daily, timeZone), 0)
 	require.Equal(t, friday.Unix(), expirationFor(thursday, throttle.Monthly, timeZone), 0)
+	require.Equal(t, friday.Unix(), expirationFor(thursday, throttle.Legacy, timeZone), 0)
 	require.Equal(t, friday.Unix(), expirationFor(thursday.Add(5*time.Minute), throttle.Monthly, timeZone), 0)
+	require.Equal(t, friday.Unix(), expirationFor(thursday.Add(5*time.Minute), throttle.Legacy, timeZone), 0)
 
 	require.Equal(t, nextMonday.Unix(), expirationFor(thursday, throttle.Weekly, timeZone), 0)
 	require.Equal(t, nextMonday.Unix(), expirationFor(thursday.Add(5*time.Minute), throttle.Weekly, timeZone), 0)

--- a/throttle/throttle.go
+++ b/throttle/throttle.go
@@ -37,6 +37,7 @@ const (
 	Daily   = "daily"
 	Weekly  = "weekly"
 	Monthly = "monthly"
+	Legacy  = "legacy" // like Monthly for old clients
 )
 
 type Settings struct {
@@ -208,7 +209,8 @@ func (cfg *redisConfig) SettingsFor(deviceID string, countryCode string, platfor
 	}
 
 	clientSupportsInterval := func(requested CapInterval) bool {
-		if requested == Monthly {
+		if requested == Legacy && len(supportedDataCaps) == 0 {
+			// legacy client
 			return true
 		}
 		for _, supported := range supportedDataCaps {
@@ -239,6 +241,6 @@ func (cfg *redisConfig) SettingsFor(deviceID string, countryCode string, platfor
 		}
 	}
 
-	log.Trace("No monthly cap available, don't throttle")
+	log.Trace("No cap available, don't throttle")
 	return nil, false
 }

--- a/throttle/throttle_test.go
+++ b/throttle/throttle_test.go
@@ -33,11 +33,13 @@ const (
 	"cn": {
 		"default": [
 			{"label": "cohort 5", "deviceFloor": 0.1, "deviceCeil": 0.5, "threshold": 3000, "rate": 300, "capResets": "weekly"},
-			{"label": "cohort 6", "deviceFloor": 0.5, "deviceCeil": 1.0, "threshold": 3100, "rate": 310, "capResets": "monthly"}
+			{"label": "cohort 6", "deviceFloor": 0.5, "deviceCeil": 1.0, "threshold": 3100, "rate": 310, "capResets": "monthly"},
+			{"label": "cohort 6", "deviceFloor": 0.5, "deviceCeil": 1.0, "threshold": 3200, "rate": 320, "capResets": "legacy"}
 		],
 		"windows": [
 			{"label": "cohort 7", "deviceFloor": 0.1, "deviceCeil": 0.5, "threshold": 4000, "rate": 400, "capResets": "weekly"},
-			{"label": "cohort 8", "deviceFloor": 0.5, "deviceCeil": 1.0, "threshold": 4100, "rate": 410, "capResets": "monthly"}
+			{"label": "cohort 8", "deviceFloor": 0.5, "deviceCeil": 1.0, "threshold": 4100, "rate": 410, "capResets": "monthly"},
+			{"label": "cohort 8", "deviceFloor": 0.5, "deviceCeil": 1.0, "threshold": 4200, "rate": 420, "capResets": "legacy"}
 		]
 	}
 }`
@@ -78,7 +80,7 @@ func TestThrottleConfig(t *testing.T) {
 	doTest(t, cfg, deviceIDInSegment1, "cn", "windows", []string{"monthly", "weekly"}, 4000, 400, "weekly", "known country, known platform, segment 1")
 	doTest(t, cfg, deviceIDInSegment2, "cn", "windows", []string{"monthly", "weekly"}, 4100, 410, "monthly", "known country, known platform, segment 2")
 	doTest(t, cfg, deviceIDInSegment1, "cn", "windows", []string{"monthly", "weekly"}, 4000, 400, "weekly", "known country, known platform, unknown segment")
-	doTest(t, cfg, deviceIDInSegment1, "cn", "windows", nil, 4100, 410, "monthly", "known country, known platform, segment 1, legacy client")
+	doTest(t, cfg, deviceIDInSegment1, "cn", "windows", nil, 4200, 420, "legacy", "known country, known platform, segment 1, legacy client")
 
 	doTest(t, cfg, deviceIDInSegment1, "cn", "", []string{"monthly", "weekly"}, 3000, 300, "weekly", "known country, unknown platform, segment 1")
 	doTest(t, cfg, deviceIDInSegment2, "cn", "", []string{"monthly", "weekly"}, 3100, 310, "monthly", "known country, unknown platform, segment 2")


### PR DESCRIPTION
For #439.

- [x] Do the tests pass? Consistently?