### PR TITLE
Add quic-go's BBR option to http-proxy

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -41,7 +41,7 @@ require (
 	github.com/getlantern/pcapper v0.0.0-20181212174440-a8b1a3ff0cde
 	github.com/getlantern/proxy v0.0.0-20201001032732-eefd72879266
 	github.com/getlantern/psmux v1.5.15-0.20200903210100-947ca5d91683
-	github.com/getlantern/quicwrapper v0.0.0-20201013170341-d27d67101f2d
+	github.com/getlantern/quicwrapper v0.0.0-20210422191427-7f1e8e47dc0b
 	github.com/getlantern/ring v0.0.0-20181206150603-dd46ce8faa01 // indirect
 	github.com/getlantern/testredis v0.0.0-20190411184556-1cd088e934c0
 	github.com/getlantern/tinywss v0.0.0-20200121221108-851921f95ad7
@@ -78,7 +78,7 @@ require (
 	gopkg.in/redis.v5 v5.2.9
 )
 
-replace github.com/lucas-clemente/quic-go => github.com/getlantern/quic-go v0.0.0-20201013165432-d264463d99fd
+replace github.com/lucas-clemente/quic-go => github.com/getlantern/quic-go v0.7.1-0.20210422183034-b5805f4c233b
 
 replace github.com/anacrolix/go-libutp => github.com/getlantern/go-libutp v1.0.3
 

--- a/go.sum
+++ b/go.sum
@@ -268,8 +268,12 @@ github.com/getlantern/psmux v1.5.15-0.20200903210100-947ca5d91683 h1:Asfm7ajzavu
 github.com/getlantern/psmux v1.5.15-0.20200903210100-947ca5d91683/go.mod h1:GtXRvtMItoflWGLPE7GNq+AdL7BnmpaaNLtDQVD1XHU=
 github.com/getlantern/quic-go v0.0.0-20201013165432-d264463d99fd h1:MoN0qJW/2JOLa96uFcpVJGNDKqDTax21vD2cRgZ7JtQ=
 github.com/getlantern/quic-go v0.0.0-20201013165432-d264463d99fd/go.mod h1:yXttHsSNxQi8AWijC/vLP+OJczXqzHSOcJrM5ITUlCg=
+github.com/getlantern/quic-go v0.7.1-0.20210422183034-b5805f4c233b h1:H+yhPm5w5HiO7Y/ZZniTVEdYh2og3GDBP0TKcs40+K8=
+github.com/getlantern/quic-go v0.7.1-0.20210422183034-b5805f4c233b/go.mod h1:yXttHsSNxQi8AWijC/vLP+OJczXqzHSOcJrM5ITUlCg=
 github.com/getlantern/quicwrapper v0.0.0-20201013170341-d27d67101f2d h1:0MtPatkhg+uy314dgBz6APOeoX0dIH82Z5ucAPNe75k=
 github.com/getlantern/quicwrapper v0.0.0-20201013170341-d27d67101f2d/go.mod h1:az7dh9l/ly3BPl1MgZZqvDroynMbemZ208hX3c7E+zo=
+github.com/getlantern/quicwrapper v0.0.0-20210422191427-7f1e8e47dc0b h1:oXgMyF/uaFA5A7PbNW3xHI2jsSkRxVOZGYZ/wq6zz7k=
+github.com/getlantern/quicwrapper v0.0.0-20210422191427-7f1e8e47dc0b/go.mod h1:hI6tn0dmAy5RAvcNsXiDn4dBWznsoAm1BjdzgQDeRM8=
 github.com/getlantern/reconn v0.0.0-20161128113912-7053d017511c h1:IkjF+RwRs8B/RsuD638eUFO2K/227OO2B1FLXGp17Ro=
 github.com/getlantern/reconn v0.0.0-20161128113912-7053d017511c/go.mod h1:kExwbqTx1krUnT9ohmXG3jayDTEBfxUKeoRzU6XucLw=
 github.com/getlantern/ring v0.0.0-20181206150603-dd46ce8faa01 h1:JyXEChj4lHy5w3hlQVnYpcH4QrBXmhEJgkxb0FPkFlM=

--- a/http-proxy/main.go
+++ b/http-proxy/main.go
@@ -47,6 +47,7 @@ var (
 	lampshadeAddr    = flag.String("lampshade-addr", "", "Address at which to listen for lampshade connections with tcp. Requires https to be true.")
 	lampshadeUTPAddr = flag.String("lampshade-utpaddr", "", "Address at which to listen for lampshade connections with utp. Requires https to be true.")
 	quicIETFAddr     = flag.String("quic-ietf-addr", "", "Address at which to listen for IETF QUIC connections.")
+	quicBBR          = flag.Bool("quic-bbr", false, "Should quic-go use BBR instead of CUBIC")
 	wssAddr          = flag.String("wss-addr", "", "Address at which to listen for WSS connections.")
 	kcpConf          = flag.String("kcpconf", "", "Path to file configuring kcp")
 
@@ -403,6 +404,7 @@ func main() {
 		ProxyProtocol:                      *proxyProtocol,
 		BBRUpstreamProbeURL:                *bbrUpstreamProbeURL,
 		QUICIETFAddr:                       *quicIETFAddr,
+		QUICUseBBR:                         *quicBBR,
 		WSSAddr:                            *wssAddr,
 		PCAPDir:                            *pcapDir,
 		PCAPIPs:                            *pcapIPs,

--- a/http_proxy.go
+++ b/http_proxy.go
@@ -143,6 +143,7 @@ type Proxy struct {
 	ProxyProtocol                      string
 	BBRUpstreamProbeURL                string
 	QUICIETFAddr                       string
+	QUICUseBBR                         bool
 	OQUICAddr                          string
 	OQUICKey                           string
 	OQUICCipher                        string
@@ -910,6 +911,7 @@ func (p *Proxy) listenQUICIETF(addr string, bordaReporter listeners.MeasuredRepo
 	config := &quicwrapper.Config{
 		MaxIncomingStreams: 1000,
 		QuicTracer:         instrument.NewQuicTracer(p.instrument),
+		UseBBR:             p.QUICUseBBR,
 	}
 
 	l, err := quicwrapper.ListenAddr(p.QUICIETFAddr, tlsConf, config)
@@ -929,6 +931,7 @@ func (p *Proxy) listenOQUIC(addr string, bordaReporter listeners.MeasuredReportF
 
 	config := &quicwrapper.Config{
 		MaxIncomingStreams: 1000,
+		UseBBR:             p.QUICUseBBR,
 	}
 
 	oquicKey, err := base64.StdEncoding.DecodeString(p.OQUICKey)


### PR DESCRIPTION
I looked at how the other settings are done, and
just copied that since I could not see how options are set
otherwise, I might be wrong though so feel free to call me out on that.

These changes will have zero connection impact on merge, they will
only change things when the flag is set to true.

Upon merging however, there will be some new prometheus metrics
due to getlantern/quicwrapper/pull/29

---

Pile up of stuff that changed with modules push (that was in scope of this change):

https://github.com/getlantern/quicwrapper/pull/29
https://github.com/getlantern/quicwrapper/pull/30
https://github.com/getlantern/quic-go/pull/20

WARNING - This template is public, do not include any sensitive information

- [x] Do the tests pass? Consistently?
- [ ] Did this change improve test coverage?
- [ ] Has it been reviewed/approved by relevant teammates?
- [x] Can it be QA’d in staging or something like staging?
- [x] Is the code in question being linted? If not, consider adding a linter step to CI. If yes, make sure the linter is happy.
- [x] Do we know how we’re going to deploy this?
- [x] Are we clear on what the support and maintenance impact is?
- [ ] Did you create new documentation? Is it accessible and in the right place?
- [ ] Has existing documentation been updated?
- [ ] Have you logged tickets for related technical debt with the label “techdebt”?