### PR TITLE
Remove UPX from build process for http-proxy-lantern

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,4 @@
 SHELL := /bin/bash
-UPX_BIN      ?= $(shell which upx)
 GIT_REVISION := $(shell git rev-parse --short HEAD)
 CHANGE_BIN   := $(shell which git-chglog)
 
@@ -52,11 +51,6 @@ require-version: guard-VERSION
 		exit 1; \
 	fi
 
-require-upx:
-	@if [ "$(UPX_BIN)" = "" ]; then \
-		echo 'Missing "upx" command. See http://upx.sourceforge.net/' && exit 1; \
-	fi
-
 require-change:
 	@ if [ "$(CHANGE_BIN)" = "" ]; then \
 		echo 'Missing "git-chglog" command. See https://github.com/git-chglog/git-chglog'; exit 1; \
@@ -85,13 +79,12 @@ dist-on-docker: $(DIST_DIR) docker-builder
 	-v $$PWD:/src -t $(DOCKER_IMAGE_TAG) /bin/bash -c \
 	'cd /src && go build -o $(DIST_DIR)/http-proxy -ldflags="-X main.revision=$$GIT_REVISION" -mod=vendor ./http-proxy'
 
-$(DIST_DIR)/http-proxy: $(SRCS) | require-upx
+$(DIST_DIR)/http-proxy: $(SRCS)
 	@if [ "$(BUILD_WITH_DOCKER)" = "true" ]; then \
 		$(MAKE) dist-on-docker; \
 	else \
 		$(MAKE) dist-on-linux; \
 	fi
-	upx $(DIST_DIR)/http-proxy
 
 distnochange: $(DIST_DIR)/http-proxy
 

--- a/README.md
+++ b/README.md
@@ -91,10 +91,6 @@ With option `-pprofaddr=localhost:6060`, you can always access lots of debug inf
 
 ## Building for distribution and deploying
 
-When building for distribution make sure you're creating a linux/amd64 binary
-and that the resulting binary is compressed with
-[upx](http://upx.sourceforge.net/).
-
 You can use the following command to do all this automatically. Note that `make dist` requires $VERSION. It will tag the repo with that version and will also generate a new changelog:
 
 ```


### PR DESCRIPTION
UPX breaks quite a few things, Mostly it breaks delve and linux-perf;
two tools that I would like to use more (either to debug coredumps
or try and make the perf of the proxy better)

After some slack convo, it seems that UPX is only used to reduce the
size of the http-proxy binary (and maybe the S3 bandwidth cost from
all proxies (~15k ish) pulling down the binary at once.)

Assuming 15k proxies all pull the http-proxy binary,

Before:
(0.019 * $0.09) * 15 000 = 25.65 US$

After:
(0.032 * $0.09) * 15 000 = 43.20 US$