### PR TITLE
Remove error severity to improve grouping

### DIFF
--- a/stackdrivererror/stackdrivererror.go
+++ b/stackdrivererror/stackdrivererror.go
@@ -26,7 +26,7 @@ func (r *Reporter) Close() {
 }
 
 func (r *Reporter) Report(severity golog.Severity, err error, stack []byte) {
-	errWithIP := fmt.Errorf("%s: %s on %s(%s)", severity.String(), err.Error(), r.proxyName, r.externalIP)
+	errWithIP := fmt.Errorf("%s on %s(%s)", err.Error(), r.proxyName, r.externalIP)
 	r.log.Tracef("Reporting error to stackdriver: %s", errWithIP)
 	r.errorClient.Report(errorreporting.Entry{
 		Error: errWithIP,

--- a/stackdrivererror/stackdrivererror_test.go
+++ b/stackdrivererror/stackdrivererror_test.go
@@ -13,8 +13,7 @@ func TestEnable(t *testing.T) {
 	log := golog.LoggerFor("stackdrivererror-test")
 	ctx := context.Background()
 
-	var percent float64
-	percent = 1.0
+	percent := 1.0
 	credsFile := os.Getenv("GOOGLE_APPLICATION_CREDENTIALS")
 	log.Debugf("Using file: %v", credsFile)
 	if credsFile != "" {


### PR DESCRIPTION
At some point stackdriver errors started getting lumped into all the same errors. Hoping that removing the severity helps!