### PR TITLE
Replace getlantern/utls imports with refraction-networking/utls

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -49,7 +49,6 @@ require (
 	github.com/getlantern/tlsdefaults v0.0.0-20171004213447-cf35cfd0b1b4
 	github.com/getlantern/tlsmasq v0.4.2
 	github.com/getlantern/tlsredis v0.0.0-20180308045249-5d4ed6dd3836
-	github.com/getlantern/utls v0.0.0-20200903013459-0c02248f7ce1
 	github.com/getlantern/waitforserver v1.0.1
 	github.com/getlantern/withtimeout v0.0.0-20160829163843-511f017cd913
 	github.com/golang/groupcache v0.0.0-20200121045136-8c9f03a8e57e
@@ -69,7 +68,7 @@ require (
 	github.com/mikioh/tcpopt v0.0.0-20180707144150-7178f18b4ea8 // indirect
 	github.com/mitchellh/panicwrap v1.0.0
 	github.com/prometheus/client_golang v1.7.1
-	github.com/refraction-networking/utls v0.0.0-20190415193640-32987941ebd3 // indirect
+	github.com/refraction-networking/utls v0.0.0-20200729012536-186025ac7b77
 	github.com/siddontang/go v0.0.0-20180604090527-bdc77568d726
 	github.com/spaolacci/murmur3 v1.1.0
 	github.com/stretchr/testify v1.7.0
@@ -91,3 +90,5 @@ replace git.apache.org/thrift.git => github.com/apache/thrift v0.0.0-20180902110
 
 // Waiting on https://github.com/mitchellh/panicwrap/pull/27 to be merged upstream
 replace github.com/mitchellh/panicwrap v1.0.0 => github.com/getlantern/panicwrap v0.0.0-20200707191944-9ba45baf8e51
+
+replace github.com/refraction-networking/utls => github.com/getlantern/utls v0.0.0-20200903013459-0c02248f7ce1

--- a/go.sum
+++ b/go.sum
@@ -560,8 +560,6 @@ github.com/prometheus/procfs v0.0.0-20181005140218-185b4288413d/go.mod h1:c3At6R
 github.com/prometheus/procfs v0.0.2/go.mod h1:TjEm7ze935MbeOT/UhFTIMYKhuLP4wbCsTZCD3I8kEA=
 github.com/prometheus/procfs v0.1.3 h1:F0+tqvhOksq22sc6iCHF5WGlWjdwj92p0udFh1VFBS8=
 github.com/prometheus/procfs v0.1.3/go.mod h1:lV6e/gmhEcM9IjHGsFOCxxuZ+z1YqCvr4OA4YeYWdaU=
-github.com/refraction-networking/utls v0.0.0-20190415193640-32987941ebd3 h1:s2Sc0GRY8eHp8AGUTvCiQuSfzgmlj0xvLBe/PPtVzLw=
-github.com/refraction-networking/utls v0.0.0-20190415193640-32987941ebd3/go.mod h1:tz9gX959MEFfFN5whTIocCLUG57WiILqtdVxI8c6Wj0=
 github.com/retailnext/hllpp v1.0.0/go.mod h1:RDpi1RftBQPUCDRw6SmxeaREsAaRKnOclghuzp/WRzc=
 github.com/rickar/props v0.0.0-20170718221555-0b06aeb2f037/go.mod h1:F1p8BNM4IXv2UcptwSp8HJOapKurodd/PYu1D6Gtn9Y=
 github.com/riobard/go-bloom v0.0.0-20200614022211-cdc8013cb5b3 h1:f/FNXud6gA3MNr8meMVVGxhp+QBTqY91tM8HjEuMjGg=

--- a/tlslistener/clienthelloconn.go
+++ b/tlslistener/clienthelloconn.go
@@ -12,7 +12,7 @@ import (
 
 	"github.com/getlantern/golog"
 	"github.com/getlantern/netx"
-	utls "github.com/getlantern/utls"
+	utls "github.com/refraction-networking/utls"
 
 	"github.com/getlantern/http-proxy-lantern/v2/instrument"
 )

--- a/tlslistener/clienthelloconn_test.go
+++ b/tlslistener/clienthelloconn_test.go
@@ -9,7 +9,7 @@ import (
 	"testing"
 	"time"
 
-	utls "github.com/getlantern/utls"
+	utls "github.com/refraction-networking/utls"
 	"github.com/stretchr/testify/assert"
 
 	"github.com/getlantern/http-proxy-lantern/v2/instrument"

--- a/tlslistener/tlslistener.go
+++ b/tlslistener/tlslistener.go
@@ -9,7 +9,7 @@ import (
 	"github.com/getlantern/golog"
 	"github.com/getlantern/tlsdefaults"
 
-	utls "github.com/getlantern/utls"
+	utls "github.com/refraction-networking/utls"
 
 	"github.com/getlantern/http-proxy-lantern/v2/instrument"
 )


### PR DESCRIPTION
I had to make this change to resolve errors I was getting trying to update `http-proxy-lantern` in Flashlight.

Specifically, I was seeing:
```
> go get github.com/getlantern/http-proxy-lantern/v2@3ff58e9ff1ec482329ac2da775e14ac340d93814
go: github.com/getlantern/utls@v0.0.0-20210519195917-8f0967667301 used for two different module paths (github.com/getlantern/utls and github.com/refraction-networking/utls)
```

Admittedly, I'm still a little confused.  It looks like these `getlantern/utls` imports have been here for a year.  I tried using Go 1.15 and Go 1.14 and got the same error.  I'm really not sure what changed to lead to this error, but the updates in this PR seem more correct regardless.  We should be consistent about import `refraction-networking/utls` and replacing it in the `go.mod` file.  

Alternatively, we could commit to using `getlantern/utls` and do away with all of the `replace` directives.  That's probably cleaner, but a bigger lift.