### PR TITLE
At least attempt to set up packet forwarding for iOS

### DIFF
--- a/http_proxy.go
+++ b/http_proxy.go
@@ -260,11 +260,10 @@ func (p *Proxy) ListenAndServe() error {
 			}()
 		}
 
-
-			if err := p.setupPacketForward(); err != nil {
-				return err
-			}
 	*/
+	if err := p.setupPacketForward(); err != nil {
+		log.Errorf("Unable to set up packet forwarding, will continue to start up: %v", err)
+	}
 	p.setupOpsContext()
 	p.setBenchmarkMode()
 	p.bm = bbr.New()


### PR DESCRIPTION
On proxies that have a correctly configured external interface, this will allow them to work. On proxies that don't, it won't prevent the proxy from starting up.