### PR TITLE
Suppress noisy dial errors

### DIFF
--- a/proxyfilters/op.go
+++ b/proxyfilters/op.go
@@ -1,7 +1,7 @@
 package proxyfilters
 
 import (
-	e2 "errors"
+	stderrors "errors"
 	"net"
 	"net/http"
 
@@ -20,20 +20,30 @@ var RecordOp = filters.FilterFunc(func(cs *filters.ConnectionState, req *http.Re
 	resp, nextCtx, err := next(cs, req)
 	if err != nil {
 		op.FailIf(err)
-		// Dumping stack trace is useful but in this case, it would create tons
-		// of noises as the filters are called recursively.
-		if e, ok := err.(errors.Error); ok {
-			// Before we do this, we should check if this is a DNS error, if so we don't
-			// want to log it, since these log.Error's get sent up to stack driver and become
-			// super noisy!
-			var dnsError *net.DNSError
-			if !e2.As(e.RootCause(), &dnsError) {
-				log.Error(e.RootCause())
-			}
-		} else {
-			log.Error(err)
-		}
+		logFilterError(err)
 	}
 	op.End()
 	return resp, nextCtx, err
 })
+
+func logFilterError(err error) {
+	var (
+		opErr  *net.OpError
+		dnsErr *net.DNSError
+	)
+	switch {
+	case stderrors.As(err, &opErr) && opErr.Timeout():
+		// Network timeouts are out of our control and create noise in StackDriver.
+		log.Debugf("%s timeout error: %v", opErr.Op, err)
+		return
+	case stderrors.As(err, &dnsErr):
+		// DNS errors are out of our control and create noise in StackDriver.
+		log.Debugf("DNS error: %v", err)
+		return
+	}
+	if e, ok := err.(errors.Error); ok {
+		// Filters are called recursively. We log only the root to reduce stack trace noise.
+		err = e.RootCause()
+	}
+	log.Error(err)
+}


### PR DESCRIPTION
The current top error in StackDriver is "i/o timeout": [link](https://console.cloud.google.com/errors/CKqD9Mb9p-i-kAE?time=P1D&project=lantern-http-proxy&authuser=0).

The stack trace indicates that this is logged [here](https://github.com/getlantern/http-proxy/blob/960392ff8d2e46a4cde78347d342de9c51fd20f7/proxyfilters/op.go#L40), which means the source of the error is [this call](https://github.com/getlantern/http-proxy/blob/960392ff8d2e46a4cde78347d342de9c51fd20f7/proxyfilters/op.go#L29) to the next filter.  The `RecordOp` filter is only used by proxy code [here](https://github.com/getlantern/http-proxy-lantern/blob/238a66099d664c16a8570bc825be7b8a6755b86e/http_proxy.go#L693), which means that the next filter would be the `cleanheadersfilter` created on the next line.  A quick inspection reveals that the `cleanheadersfilter` [does not generate errors of its own](https://github.com/getlantern/http-proxy-lantern/blob/238a66099d664c16a8570bc825be7b8a6755b86e/cleanheadersfilter/cleanheadersfilter.go#L19-L32).

Looking at the [use of the filter chain](https://github.com/getlantern/http-proxy-lantern/blob/238a66099d664c16a8570bc825be7b8a6755b86e/http_proxy.go#L270-L291), we can see that, at least for non-WSS proxies, the `cleanheadersfilter` is the last in the chain.  So the `next` function returning the error must be provided by whoever calls `Apply` on the filter chain.  As seen in the previous link, the filter chain is provided to `getlantern/http-proxy/server.New`, where it is [passed to `getlantern/proxy.New`](https://github.com/getlantern/http-proxy/blob/86faba7957505043b774215478f7754b371cd86c/server/server.go#L72).  There, `Apply` is only ever called [here](https://github.com/getlantern/proxy/blob/e927470b2fa2562217db69cb4151b247ef37cf42/proxy_http.go#L198), which means that `next` is initialized [as nextCONNECT](https://github.com/getlantern/proxy/blob/e927470b2fa2562217db69cb4151b247ef37cf42/proxy_http.go#L117) or [nextNonCONNECT](https://github.com/getlantern/proxy/blob/e927470b2fa2562217db69cb4151b247ef37cf42/proxy_http.go#L147).

In the case of `nextCONNECT`, an error is only returned [here](https://github.com/getlantern/proxy/blob/e927470b2fa2562217db69cb4151b247ef37cf42/proxy_connect.go#L98-L103) (n.b. `badGateway` returns the error unmodified), which means the original "i/o timeout" came from the dial.

In the case of `nextNonCONNECT`, an error is only returned [here](https://github.com/getlantern/proxy/blob/e927470b2fa2562217db69cb4151b247ef37cf42/proxy_http.go#L176-L178), which means that the original "i/o timeout" came from the `RoundTrip` call (and presumably a `Read` call on the underlying transport connection).  In either case, the error appears to originate [in the `net` package](https://cs.opensource.google/go/go/+/refs/tags/go1.17.3:src/net/net.go;l=576-589) and should pass `errors.As` for a `*net.OpError`.

The proposal in this PR is to suppress these network timeout errors as they are out of our control and therefore just noise.  I'm still logging them on DEBUG so that we can see them in proxy logs if we'd like.

Side-note: the filters mechanism makes tracing these kinds of things pretty onerous.  I wonder if we can come up with something better.