### PR TITLE
Reduce the number of idle connections to the reporting redis

### DIFF
--- a/redis/redis.go
+++ b/redis/redis.go
@@ -18,6 +18,7 @@ func NewClient(redisURL string) (*redis.Client, error) {
 	return redis.NewClient(&redis.Options{
 		Addr:     opt.Addr,
 		Password: opt.Password,
+		PoolSize: 2,
 		TLSConfig: &tls.Config{
 			ClientSessionCache: tls.NewLRUClientSessionCache(20),
 		},


### PR DESCRIPTION
The relevant default set by the redis library is 10*GOMAXPROCS. We don't need very many, since we only publish every couple minutes, and having so many for each instance is dangerous, because there are thousands of proxy instances.

r? @myleshorton 