### PR TITLE
Simplify docker build and statically link binary

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,26 +1,9 @@
 # This docker machine is able to compile http-proxy-lantern for Ubuntu Linux
 
-FROM --platform=linux/amd64 ubuntu:20.04
+FROM golang:1.18
+# Note that we don't use alpine here because we need at least gcc.
 
-# Avoids the build hanging on anything that might expect user interaction.
-ARG DEBIAN_FRONTEND=noninteractive
-
-# Requisites for building Go.
-RUN apt-get update && apt-get install -y git tar gzip curl hostname
-
-# Compilers and tools for CGO.
-RUN apt-get install -y build-essential pkg-config make libpcap-dev
-
-# Getting Go.
-ENV GOROOT /usr/local/go
-ENV GOPATH /
-
-ENV PATH $PATH:$GOROOT/bin
-
-ARG go_version
-ENV GO_VERSION $go_version
-ENV GO_PACKAGE_URL https://storage.googleapis.com/golang/$GO_VERSION.linux-amd64.tar.gz
-RUN curl -sSL $GO_PACKAGE_URL | tar -xvzf - -C /usr/local
+RUN apt-get update && apt-get install -y build-essential pkg-config make libpcap-dev
 
 ENV WORKDIR /src
 

--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ Run a Lantern client accordingly from `lantern-desktop`, as in:
 
 If you're developing a new transport, you can also add new versions of those files for that transport as you're testing.
 
-You have two options to test it: the Lantern client or [checkfallbacks](https://github.com/getlantern/lantern/tree/valencia/src/github.com/getlantern/checkfallbacks).
+You have two options to test it: the Lantern client or [checkfallbacks](https://github.com/getlantern/checkfallbacks).
 
 Keep in mind that they will need to send some headers in order to avoid receiving 404 messages (the chained server response if you aren't providing them).
 
@@ -155,4 +155,3 @@ To view proxy logs on a given machine, run:
 ```
 journalctl -e -u http-proxy
 ```
-


### PR DESCRIPTION
This just uses a more standard Dockerfile and changes this to statically link the binary so we don't have to worry as much about the host system.