### PR TITLE
Add ability to configure first TLS session ticket key

### DIFF
--- a/http-proxy/main.go
+++ b/http-proxy/main.go
@@ -74,6 +74,12 @@ var (
 	token                = flag.String("token", "", "Lantern token")
 	sessionTicketKeyFile = flag.String("sessionticketkey", "", "File name for storing rotating session ticket keys")
 
+	// This flag was added after sessionticketkey (above) to allow the deploying server to configure
+	// a key for the proxy without the need to touch its local files. In the interest of backwards
+	// compatibility, sessionticketkey was retained and firstSessionTicketKey was implemented to be
+	// compatible with sessionticketkey.
+	firstSessionTicketKey = flag.String("first-session-ticket-key", "", "initial session ticket key; never expires; 32-byte string, base64-encoded")
+
 	lampshadeKeyCacheSize     = flag.Int("lampshade-keycache-size", 0, "set this to a positive value to cache client keys and reject duplicates to thwart replay attacks")
 	lampshadeMaxClientInitAge = flag.Duration("lampshade-max-clientinit-age", 0, "set this to a positive value to limit the age of client init messages to thwart replay attacks")
 
@@ -349,6 +355,7 @@ func main() {
 		IdleTimeout:                        time.Duration(*idleClose) * time.Second,
 		KeyFile:                            *keyfile,
 		SessionTicketKeyFile:               *sessionTicketKeyFile,
+		FirstSessionTicketKey:              *firstSessionTicketKey,
 		Track:                              *track,
 		Pro:                                *pro,
 		ProxiedSitesSamplePercentage:       *proxiedSitesSamplePercentage,

--- a/http_proxy.go
+++ b/http_proxy.go
@@ -136,6 +136,7 @@ type Proxy struct {
 	PacketForwardAddr                  string
 	ExternalIntf                       string
 	SessionTicketKeyFile               string
+	FirstSessionTicketKey              string
 	RequireSessionTickets              bool
 	MissingTicketReaction              tlslistener.HandshakeReaction
 	TLSListenerAllowTLS13              bool
@@ -388,7 +389,10 @@ func (p *Proxy) wrapTLSIfNecessary(fn listenerBuilderFN) listenerBuilderFN {
 		}
 
 		if p.HTTPS {
-			l, err = tlslistener.Wrap(l, p.KeyFile, p.CertFile, p.SessionTicketKeyFile, p.RequireSessionTickets, p.MissingTicketReaction, p.TLSListenerAllowTLS13, p.instrument)
+			l, err = tlslistener.Wrap(
+				l, p.KeyFile, p.CertFile, p.SessionTicketKeyFile, p.FirstSessionTicketKey,
+				p.RequireSessionTickets, p.MissingTicketReaction, p.TLSListenerAllowTLS13,
+				p.instrument)
 			if err != nil {
 				return nil, err
 			}
@@ -851,7 +855,9 @@ func (p *Proxy) listenWSS(addr string) (net.Listener, error) {
 	}
 
 	if p.HTTPS {
-		l, err = tlslistener.Wrap(l, p.KeyFile, p.CertFile, p.SessionTicketKeyFile, p.RequireSessionTickets, p.MissingTicketReaction, p.TLSListenerAllowTLS13, p.instrument)
+		l, err = tlslistener.Wrap(
+			l, p.KeyFile, p.CertFile, p.SessionTicketKeyFile, p.FirstSessionTicketKey,
+			p.RequireSessionTickets, p.MissingTicketReaction, p.TLSListenerAllowTLS13, p.instrument)
 		if err != nil {
 			return nil, err
 		}

--- a/tlslistener/clienthelloconn_test.go
+++ b/tlslistener/clienthelloconn_test.go
@@ -36,7 +36,9 @@ func TestAbortOnHello(t *testing.T) {
 		t.Run(tc.response.action, func(t *testing.T) {
 			l, _ := net.Listen("tcp", ":0")
 			defer l.Close()
-			hl, err := Wrap(l, "../test/data/server.key", "../test/data/server.crt", "../test/testtickets", true, tc.response, false, instrument.NoInstrument{})
+			hl, err := Wrap(
+				l, "../test/data/server.key", "../test/data/server.crt", "../test/testtickets", "",
+				true, tc.response, false, instrument.NoInstrument{})
 			assert.NoError(t, err)
 			defer hl.Close()
 
@@ -76,7 +78,9 @@ func TestAbortOnHello(t *testing.T) {
 			rawConn, err := net.Dial("tcp", l.Addr().String())
 			assert.NoError(t, err)
 			ucfg := &utls.Config{ServerName: "microsoft.com"}
-			maintainSessionTicketKey(&tls.Config{}, "../test/testtickets", func(keys [][32]byte) { ucfg.SetSessionTicketKeys(keys) })
+			maintainSessionTicketKey(
+				&tls.Config{}, "../test/testtickets", nil,
+				func(keys [][32]byte) { ucfg.SetSessionTicketKeys(keys) })
 			ss := &utls.ClientSessionState{}
 			ticket := make([]byte, 120)
 			rand.Read(ticket)


### PR DESCRIPTION
This allows the deploying server to configure TLS session tickets without touching the proxy's local files.

Long-term, we could get rid of `sessionticketkey` once we've fully moved over to lantern-cloud.