### PR TITLE
Make sure that bbr bandwidth estimate is available on multiplexed pro…

### DIFF
--- a/bbr/bbr.go
+++ b/bbr/bbr.go
@@ -2,17 +2,16 @@
 //
 // Bandwidth estimates are provided to clients following the below protocol:
 //
-// 1. On every inbound connection, we interrogate BBR congestion control
-//    parameters to determine the estimated bandwidth, extrapolate this to what
-//    we would expected for a 2.5 MB transfer using a linear estimation based on
-//    how much data has actually been transferred on the connection and then
-//    maintain an exponential moving average (EMA) of these estimates per remote
-//    (client) IP.
-// 2. If a client includes HTTP header "X-BBR: <anything>", we include header
-//    X-BBR-ABE: <EMA bandwidth in Mbps> in the HTTP response.
-// 3. If a client includes HTTP header "X-BBR: clear", we clear stored estimate
-//    data for the client's IP.
-//
+//  1. On every inbound connection, we interrogate BBR congestion control
+//     parameters to determine the estimated bandwidth, extrapolate this to what
+//     we would expected for a 2.5 MB transfer using a linear estimation based on
+//     how much data has actually been transferred on the connection and then
+//     maintain an exponential moving average (EMA) of these estimates per remote
+//     (client) IP.
+//  2. If a client includes HTTP header "X-BBR: <anything>", we include header
+//     X-BBR-ABE: <EMA bandwidth in Mbps> in the HTTP response.
+//  3. If a client includes HTTP header "X-BBR: clear", we clear stored estimate
+//     data for the client's IP.
 package bbr
 
 import (
@@ -21,10 +20,6 @@ import (
 
 	"github.com/getlantern/golog"
 	"github.com/getlantern/proxy/v2/filters"
-)
-
-const (
-	nanosPerMilli = 1000000
 )
 
 var (

--- a/bbr/bbr_linux.go
+++ b/bbr/bbr_linux.go
@@ -23,7 +23,7 @@ type middleware struct {
 }
 
 func New() Middleware {
-	log.Debug("Tracking bbr metrics on Linux")
+	log.Debug("Running on linux, bbr metrics available (but not necessarily enabled)")
 	return &middleware{
 		statsByClient: make(map[string]*stats),
 	}

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/blang/semver v3.5.1+incompatible
 	github.com/dustin/go-humanize v1.0.0
 	github.com/getlantern/bbrconn v0.0.0-20180619163322-86cf8c16f3d0
-	github.com/getlantern/cmux/v2 v2.0.0-20200905031936-c55b16ee8462
+	github.com/getlantern/cmux/v2 v2.0.0-20230228131144-addc208d233b
 	github.com/getlantern/cmuxprivate v0.0.0-20200905032931-afb63438e40b
 	github.com/getlantern/ema v0.0.0-20190620044903-5943d28f40e4
 	github.com/getlantern/enhttp v0.0.0-20190401024120-a974fa851e3c
@@ -35,7 +35,7 @@ require (
 	github.com/getlantern/ratelimit v0.0.0-20220926192648-933ab81a6fc7
 	github.com/getlantern/tinywss v0.0.0-20200121221108-851921f95ad7
 	github.com/getlantern/tlsdefaults v0.0.0-20171004213447-cf35cfd0b1b4
-	github.com/getlantern/tlsmasq v0.4.6
+	github.com/getlantern/tlsmasq v0.4.7-0.20230302000139-6e479a593298
 	github.com/getlantern/tlsutil v0.5.1
 	github.com/getlantern/waitforserver v1.0.1
 	github.com/getlantern/withtimeout v0.0.0-20160829163843-511f017cd913
@@ -81,7 +81,7 @@ require (
 	github.com/fsnotify/fsnotify v1.5.4 // indirect
 	github.com/getlantern/bufconn v0.0.0-20190625204133-a08544339f8d // indirect
 	github.com/getlantern/byteexec v0.0.0-20170405023437-4cfb26ec74f4 // indirect
-	github.com/getlantern/cmux v0.0.0-20200905031936-c55b16ee8462 // indirect
+	github.com/getlantern/cmux v0.0.0-20230301223233-dac79088a4c0 // indirect
 	github.com/getlantern/context v0.0.0-20220418194847-3d5e7a086201 // indirect
 	github.com/getlantern/elevate v0.0.0-20200430163644-2881a121236d // indirect
 	github.com/getlantern/eventual v0.0.0-20180125201821-84b02499361b // indirect
@@ -192,4 +192,4 @@ replace github.com/refraction-networking/utls => github.com/getlantern/utls v0.0
 // over 'require' to fully remove references to 0.5.6 in go.sum
 replace github.com/ulikunitz/xz => github.com/ulikunitz/xz v0.5.8
 
-replace github.com/Jigsaw-Code/outline-ss-server => github.com/getlantern/lantern-shadowsocks v1.3.6-0.20230114153732-0193919d4860
+replace github.com/Jigsaw-Code/outline-ss-server => github.com/getlantern/lantern-shadowsocks v1.3.6-0.20230301223223-150b18ac427d

--- a/go.sum
+++ b/go.sum
@@ -148,10 +148,11 @@ github.com/getlantern/bytecounting v0.0.0-20190530140808-3b3f10d3b9ab h1:bKsTXN1
 github.com/getlantern/bytecounting v0.0.0-20190530140808-3b3f10d3b9ab/go.mod h1:O/UvKlcgUd/tsplTbFesvYtqGENHVE/yO8DJ1sd+x+g=
 github.com/getlantern/byteexec v0.0.0-20170405023437-4cfb26ec74f4 h1:Nqmy8i81dzokjNHpyOg24gnQBeGRF7D51m8HmBRNn0Y=
 github.com/getlantern/byteexec v0.0.0-20170405023437-4cfb26ec74f4/go.mod h1:4WCQkaCIwta0KlF9bQZA1jYqp8bzIS2PeCqjnef8nZ8=
-github.com/getlantern/cmux v0.0.0-20200905031936-c55b16ee8462 h1:eJkOdQpAgT9/v9KJD0UdQ90CGb7m8nXL33Qhk0AQ4x4=
-github.com/getlantern/cmux v0.0.0-20200905031936-c55b16ee8462/go.mod h1:48COjs7jITfhkdw82LeMDQtrISx0CQG3/W0Ycr2UafM=
-github.com/getlantern/cmux/v2 v2.0.0-20200905031936-c55b16ee8462 h1:i5/Pd2raSQs59f0twxO/Fm3FaxpEsSSZKC0mxWnXumM=
+github.com/getlantern/cmux v0.0.0-20230301223233-dac79088a4c0 h1:JlVdpDQThkcqlMoqpn89ZfNUpxNTUNqUrTFacBJvIqU=
+github.com/getlantern/cmux v0.0.0-20230301223233-dac79088a4c0/go.mod h1:48COjs7jITfhkdw82LeMDQtrISx0CQG3/W0Ycr2UafM=
 github.com/getlantern/cmux/v2 v2.0.0-20200905031936-c55b16ee8462/go.mod h1:oJz1ghfzM796DpGP0et6Gbc3si2Zn3/7l7KxxK/KXQ0=
+github.com/getlantern/cmux/v2 v2.0.0-20230228131144-addc208d233b h1:wdB3MA0/9x0Z0cwmQWx3oJjPF0T2+E0gS9vtZzT1tic=
+github.com/getlantern/cmux/v2 v2.0.0-20230228131144-addc208d233b/go.mod h1:oJz1ghfzM796DpGP0et6Gbc3si2Zn3/7l7KxxK/KXQ0=
 github.com/getlantern/cmuxprivate v0.0.0-20200905032931-afb63438e40b h1:yBspzs66rMnW1KuXUoXGvW2WVUQ2+r4IBsTLM0dQrbU=
 github.com/getlantern/cmuxprivate v0.0.0-20200905032931-afb63438e40b/go.mod h1:WIunQ/nFvkQAP89tY2CX4R5kj9A1OJhjA3KmP6nj4o4=
 github.com/getlantern/context v0.0.0-20190109183933-c447772a6520/go.mod h1:L+mq6/vvYHKjCX2oez0CgEAJmbq1fbb/oNJIWQkBybY=
@@ -217,8 +218,8 @@ github.com/getlantern/keyman v0.0.0-20210218183930-5e48f8ced961 h1:FEBpsJqYoGfiO
 github.com/getlantern/keyman v0.0.0-20210218183930-5e48f8ced961/go.mod h1:VMD668wW8As25Yb7/m9CqnsOk4zKrvFM/2eJgP6HAXE=
 github.com/getlantern/lampshade v0.0.0-20200303040944-fe53f13203e9 h1:n2t63QvweEs53Kpy7QbXv6JRSfXpDTTgPMT4cNTOt8g=
 github.com/getlantern/lampshade v0.0.0-20200303040944-fe53f13203e9/go.mod h1:Zqiq4op+E689yjuJACMLURzE9XUGj48UDZP7h8aN+kk=
-github.com/getlantern/lantern-shadowsocks v1.3.6-0.20230114153732-0193919d4860 h1:eMJ05nKDxgglPGWvAqcs4e23RRB3NoofVCtD0DDOV/Q=
-github.com/getlantern/lantern-shadowsocks v1.3.6-0.20230114153732-0193919d4860/go.mod h1:YCEW57ujbWaUeGRMhRjF0OgMBqUTNb3QsErbaQZq5K8=
+github.com/getlantern/lantern-shadowsocks v1.3.6-0.20230301223223-150b18ac427d h1:YwH3hgY1qtp1J1V8iBx58wB+mAY6L7N1s+qYqNJgDjM=
+github.com/getlantern/lantern-shadowsocks v1.3.6-0.20230301223223-150b18ac427d/go.mod h1:Wwa1uDdu6LxVRANcN2dQ+aNI0rY+km+dqHW2G9Qm34k=
 github.com/getlantern/measured v0.0.0-20170302221919-0582bf799783/go.mod h1:5OW2WJitCKExpSw2bploW2fM7PjOd6QnLqyp+IqToqU=
 github.com/getlantern/measured v0.0.0-20210507000559-ec5307b2b8be h1:rfdOTeKew6zcpf5BQ566WInLINdZARimtWVLcgP/a4I=
 github.com/getlantern/measured v0.0.0-20210507000559-ec5307b2b8be/go.mod h1:QG6d9+nAxD1PjVjgGLUUHPZBQUp20/h7j8a3kxd/8Rc=
@@ -275,8 +276,8 @@ github.com/getlantern/tinywss v0.0.0-20200121221108-851921f95ad7 h1:wVcJbQS7pf4h
 github.com/getlantern/tinywss v0.0.0-20200121221108-851921f95ad7/go.mod h1:ZLyPOKtNWU4vWnAiRiNQ7hbfLMqCEuj1DgQWBtHp7tQ=
 github.com/getlantern/tlsdefaults v0.0.0-20171004213447-cf35cfd0b1b4 h1:73U3J4msGw3cXeKtCEbY7hbOdD6aX8gJv8BOu+VagF8=
 github.com/getlantern/tlsdefaults v0.0.0-20171004213447-cf35cfd0b1b4/go.mod h1:f8WmDYKFOaC5/y0d3GWl6UKf1ZbSlIoMzkuC8x7pUhg=
-github.com/getlantern/tlsmasq v0.4.6 h1:yk+XnAgB9XofhJ9leFR/SotRlLLtS2vElvjB43Xjn7E=
-github.com/getlantern/tlsmasq v0.4.6/go.mod h1:If80SpH0K1QvlZ5xeLlp3Vba73s8r1aCZzSmQNKN/pY=
+github.com/getlantern/tlsmasq v0.4.7-0.20230302000139-6e479a593298 h1:GxhCQ6zLnIeaIw2gtZsM7hSlpXHdd8DoXSEPObSHMuk=
+github.com/getlantern/tlsmasq v0.4.7-0.20230302000139-6e479a593298/go.mod h1:vcDVZe3TGEqd0nD0tVvqKoyGHY+5bPxCa+IklxroKd0=
 github.com/getlantern/tlsutil v0.5.1 h1:Cn19aDidw4+yufrQaCAYjZir3g1QaObs1xf4qzez3CA=
 github.com/getlantern/tlsutil v0.5.1/go.mod h1:lVgvr4nxuQ1ocOho90UB6LnHFlpP16TXAGpHR8Z0QnI=
 github.com/getlantern/utls v0.0.0-20200903013459-0c02248f7ce1 h1:+Egmu6VMMPm8/FHz8TOtQ1Usn3zg0gkS7ZHrLFycyok=

--- a/shadowsocks/local_test.go
+++ b/shadowsocks/local_test.go
@@ -9,9 +9,10 @@ import (
 	"testing"
 	"time"
 
+	logging "github.com/op/go-logging"
+
 	"github.com/getlantern/fdcount"
 	"github.com/getlantern/grtrack"
-	logging "github.com/op/go-logging"
 
 	"github.com/Jigsaw-Code/outline-ss-server/client"
 	"github.com/Jigsaw-Code/outline-ss-server/service"
@@ -52,7 +53,7 @@ func TestLocalUpstreamHandling(t *testing.T) {
 	testMetrics := &metrics.NoOpMetrics{}
 
 	options := &ListenerOptions{
-		Listener: l0,
+		Listener: &tcpListenerAdapter{l0},
 		Ciphers:  cipherList,
 		Metrics:  testMetrics,
 		Timeout:  200 * time.Millisecond,
@@ -73,12 +74,12 @@ func TestLocalUpstreamHandling(t *testing.T) {
 				buf := make([]byte, 2*len(req))
 				n, err := c.Read(buf)
 				if err != nil {
-					logger.Errorf("error reading: %v", err)
+					log.Errorf("error reading: %v", err)
 					return
 				}
 				buf = buf[:n]
 				if !bytes.Equal(buf, req) {
-					logger.Errorf("unexpected request %v %v", buf, req)
+					log.Errorf("unexpected request %v %v", buf, req)
 					return
 				}
 				c.Write(res)
@@ -138,7 +139,7 @@ func TestConcurrentLocalUpstreamHandling(t *testing.T) {
 	testMetrics := &metrics.NoOpMetrics{}
 
 	options := &ListenerOptions{
-		Listener: l0,
+		Listener: &tcpListenerAdapter{l0},
 		Ciphers:  cipherList,
 		Metrics:  testMetrics,
 		Timeout:  200 * time.Millisecond,
@@ -158,14 +159,14 @@ func TestConcurrentLocalUpstreamHandling(t *testing.T) {
 				buf := make([]byte, 2*reqLen)
 				n, err := c.Read(buf)
 				if err != nil {
-					logger.Errorf("error reading: %v", err)
+					log.Errorf("error reading: %v", err)
 					return
 				}
 				buf = buf[:n]
 
 				res := ress[string(buf)]
 				if res == "" {
-					logger.Errorf("unexpected request %v", buf)
+					log.Errorf("unexpected request %v", buf)
 					return
 				}
 				c.Write([]byte(res))

--- a/shadowsocks/logger.go
+++ b/shadowsocks/logger.go
@@ -1,5 +1,0 @@
-package shadowsocks
-
-import logging "github.com/op/go-logging"
-
-var logger = logging.MustGetLogger("shadowsocks")

--- a/tlsmasq/tlsmasq_test.go
+++ b/tlsmasq/tlsmasq_test.go
@@ -11,11 +11,13 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/getlantern/http-proxy-lantern/v2/bbr"
 	"github.com/getlantern/keyman"
 	"github.com/getlantern/tlsmasq"
 	"github.com/getlantern/tlsmasq/ptlshs"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
 func TestWrap(t *testing.T) {
@@ -77,8 +79,12 @@ func TestWrap(t *testing.T) {
 		assert.NoError(t, err, "got error from nonFatalErrorsHandler")
 	}
 
+	// Wrap with BBR listener to make sure that doesn't cause problems for tlsmasq
+	b := bbr.New()
+	wl := b.Wrap(l)
+
 	tlsmasqListener, err := Wrap(
-		l, proxyCertFile, proxyKeyFile, proxiedListener.Addr().String(), secretString,
+		wl, proxyCertFile, proxyKeyFile, proxiedListener.Addr().String(), secretString,
 		tls.VersionTLS12, []uint16{tls.TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA}, nonFatalErrorsHandler)
 	require.NoError(t, err)
 	defer tlsmasqListener.Close()


### PR DESCRIPTION
…tocols and tlsmasq

It turns out that we had several protocols that weren't reporting BBR metrics. This fixes that.

- Enable BBR wrapper for TLSMask (@hwh33 is that okay? I couldn't think of a reason why it needs to be disabled)
- Use [updated tlsmasq](https://github.com/getlantern/tlsmasq/pull/42)
- Update [shadowsocks](https://github.com/getlantern/lantern-shadowsocks/pull/16) library to allow applying bbr wrapper
- Fix multiplexed protocols by pulling in a [cmux fix](https://github.com/getlantern/cmux/pull/20) that allows peering past the cmux connection to the wrapped connection

I tested this by manually deploying to a tlsmasq, a shadowsocks and an https_multiplex proxy and making sure that I get BBR estimates.
