### PR TITLE
Add http3 transport support

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/OperatorFoundation/Starbridge-go/Starbridge/v3 v3.0.15
 	github.com/blang/semver v3.5.1+incompatible
 	github.com/dustin/go-humanize v1.0.0
-	github.com/getlantern/broflake v0.0.0-20230712151102-babe00bace7f
+	github.com/getlantern/broflake v0.0.0-20230712153547-aa716566e960
 	github.com/getlantern/cmux/v2 v2.0.0-20230228131144-addc208d233b
 	github.com/getlantern/cmuxprivate v0.0.0-20200905032931-afb63438e40b
 	github.com/getlantern/enhttp v0.0.0-20190401024120-a974fa851e3c
@@ -30,7 +30,7 @@ require (
 	github.com/getlantern/packetforward v0.0.0-20201001150407-c68a447b0360
 	github.com/getlantern/proxy/v2 v2.0.1-0.20220303164029-b34b76e0e581
 	github.com/getlantern/psmux v1.5.15-0.20200903210100-947ca5d91683
-	github.com/getlantern/quicwrapper v0.0.0-20230712142605-583786d9d29c
+	github.com/getlantern/quicwrapper v0.0.0-20230712153452-6632f7a4b6ed
 	github.com/getlantern/ratelimit v0.0.0-20220926192648-933ab81a6fc7
 	github.com/getlantern/tinywss v0.0.0-20200121221108-851921f95ad7
 	github.com/getlantern/tlsdefaults v0.0.0-20171004213447-cf35cfd0b1b4

--- a/go.sum
+++ b/go.sum
@@ -121,8 +121,8 @@ github.com/fsnotify/fsnotify v1.4.9/go.mod h1:znqG4EE+3YCdAaPaxE2ZRY/06pZUdp0tY4
 github.com/fsnotify/fsnotify v1.5.4 h1:jRbGcIw6P2Meqdwuo0H1p6JVLbL5DHKAKlYndzMwVZI=
 github.com/fsnotify/fsnotify v1.5.4/go.mod h1:OVB6XrOHzAwXMpEM7uPOzcehqUV2UqJxmVXmkdnm1bU=
 github.com/getlantern/appdir v0.0.0-20160830121117-659a155d06e8/go.mod h1:3vR6+jQdWfWojZ77w+htCqEF5MO/Y2twJOpAvFuM9po=
-github.com/getlantern/broflake v0.0.0-20230712151102-babe00bace7f h1:UnI9/N8xF6HHgq9o7lB3l191XNkjhvbFZJNQtJ4gF8U=
-github.com/getlantern/broflake v0.0.0-20230712151102-babe00bace7f/go.mod h1:JsNvKzcKmNB0DfrlMsw3BZXauqosabqt0zUag2hMB0Y=
+github.com/getlantern/broflake v0.0.0-20230712153547-aa716566e960 h1:+SwjCZpAtFtv8BrTwIsazOOQk+P93BBrL1bxPrkvJTY=
+github.com/getlantern/broflake v0.0.0-20230712153547-aa716566e960/go.mod h1:muHXUQvxnDI5/ArMU44CKXeiFuzH9wYWZj9Scbiy6DU=
 github.com/getlantern/bufconn v0.0.0-20190625204133-a08544339f8d h1:gE5pWSEYfMvSETsTanqINNLmv+nuyUjwcm9jOyqJJZI=
 github.com/getlantern/bufconn v0.0.0-20190625204133-a08544339f8d/go.mod h1:d6O4RY+V87kIt4o9wru4SaNo7C2NAkD3YnmJFXEpODo=
 github.com/getlantern/bytecounting v0.0.0-20190530140808-3b3f10d3b9ab h1:bKsTXN1XgjiWuciuEChVIPFXWD8sTASsvjkMAGMEb/4=
@@ -244,8 +244,8 @@ github.com/getlantern/proxy/v2 v2.0.1-0.20220303164029-b34b76e0e581 h1:7NrSoq9ce
 github.com/getlantern/proxy/v2 v2.0.1-0.20220303164029-b34b76e0e581/go.mod h1:81jIwwI/5NGYj2CSvbsZapcTe87jd6AeEu6yJD1NKIg=
 github.com/getlantern/psmux v1.5.15-0.20200903210100-947ca5d91683 h1:Asfm7ajzavuSZC+5b+tPwXwyvlw188NM9hKM7wNMNGg=
 github.com/getlantern/psmux v1.5.15-0.20200903210100-947ca5d91683/go.mod h1:GtXRvtMItoflWGLPE7GNq+AdL7BnmpaaNLtDQVD1XHU=
-github.com/getlantern/quicwrapper v0.0.0-20230712142605-583786d9d29c h1:awAL8a8bst/fDsq6lPVizKkU8T3ag1s541Eiq2u71RQ=
-github.com/getlantern/quicwrapper v0.0.0-20230712142605-583786d9d29c/go.mod h1:VIVKENhDaV5T+KPMHPHr3nev4JjxdLE7X6HreEOpnY8=
+github.com/getlantern/quicwrapper v0.0.0-20230712153452-6632f7a4b6ed h1:FYrAH+aOLB6Kbvq/wamYDgsixQGmdgauZyDyVQqPojI=
+github.com/getlantern/quicwrapper v0.0.0-20230712153452-6632f7a4b6ed/go.mod h1:TLDFfHyQWi3IK/82KHJZOEfcgJLb6tQHcnVpGrQ2ojA=
 github.com/getlantern/ratelimit v0.0.0-20220926192648-933ab81a6fc7 h1:47FJ5kTeXc3I1VPpi2hWW9I16/Y3K0cpUq/B7oWJGF8=
 github.com/getlantern/ratelimit v0.0.0-20220926192648-933ab81a6fc7/go.mod h1:OOqKCIkspqXtIWEex4uhH1H9l7NGekT9i3Hs591ZDk4=
 github.com/getlantern/reconn v0.0.0-20161128113912-7053d017511c h1:IkjF+RwRs8B/RsuD638eUFO2K/227OO2B1FLXGp17Ro=


### PR DESCRIPTION
This is the server side of https://github.com/getlantern/grants/issues/322

It's worth noting this actually adds HTTP/3 via WebTransport, as we need a way to get a generic byte stream.