### PR TITLE
Require config server auth token flag

### DIFF
--- a/http-proxy/main.go
+++ b/http-proxy/main.go
@@ -269,6 +269,10 @@ func main() {
 		}
 	}()
 
+	if *cfgSvrAuthToken == "" {
+		log.Fatal("Config server auth token is required")
+	}
+
 	if *lampshadeAddr != "" && !*https {
 		log.Fatal("Use of lampshade requires https flag to be true")
 	}


### PR DESCRIPTION
Turns out this flag is essentially required for the Lantern network to function properly.  Otherwise, clients will not be able to request config through their proxies.