### PR TITLE
Revert "Revert "Actually require session ticket keys""

### DIFF
--- a/tlslistener/clienthelloconn_test.go
+++ b/tlslistener/clienthelloconn_test.go
@@ -107,9 +107,6 @@ func TestSuccess(t *testing.T) {
 	l, _ := net.Listen("tcp", ":0")
 	defer l.Close()
 
-	// We specify in-memory session ticket keys to make sure that key rotation for these is working
-	// but that we are NOT requiring clients to present session tickets (yet).
-	// See https://github.com/getlantern/engineering/issues/292#issuecomment-1687180508.
 	sessionTicketKeys := make([]byte, keySize)
 	_, err := rand.Read(sessionTicketKeys)
 	require.NoError(t, err)
@@ -140,7 +137,7 @@ func TestSuccess(t *testing.T) {
 	// Dial once to obtain a valid session ticket (this is works because we're dialing localhost)
 	ucfg := &utls.Config{
 		InsecureSkipVerify: true,
-		// ClientSessionCache: utls.NewLRUClientSessionCache(10),
+		ClientSessionCache: utls.NewLRUClientSessionCache(10),
 	}
 	conn, err := utls.Dial("tcp", l.Addr().String(), ucfg)
 	require.NoError(t, err)

--- a/tlslistener/tlslistener.go
+++ b/tlslistener/tlslistener.go
@@ -44,12 +44,7 @@ func Wrap(wrapped net.Listener, keyFile, certFile, sessionTicketKeyFile, firstSe
 
 	expectTicketsFromFile := sessionTicketKeyFile != ""
 	expectTicketsInMemory := sessionTicketKeys != ""
-	// For now, we don't expect tickets if we're only maintaining them in memory.
-	// This will allow clients who are still using session tickets generated with old
-	// disk-based keys to obtain new session tickets without hitting a missing ticket
-	// reaction. See https://github.com/getlantern/engineering/issues/292.
-	// expectTickets := expectTicketsFromFile || expectTicketsInMemory
-	expectTickets := expectTicketsFromFile
+	expectTickets := expectTicketsFromFile || expectTicketsInMemory
 
 	listener := &tlslistener{
 		wrapped:               wrapped,
@@ -71,7 +66,6 @@ func Wrap(wrapped net.Listener, keyFile, certFile, sessionTicketKeyFile, firstSe
 		for _, k := range keys {
 			listener.ticketKeys = append(listener.ticketKeys, utls.TicketKeyFromBytes(k))
 		}
-		log.Debug("Finished setting listener keys")
 	}
 
 	if expectTicketsFromFile {


### PR DESCRIPTION
I tested this on `charmander-ea58663c-99c8-4a75-954f-468ffd4aab1b`. I followed this sequence:

1. Connect my client to the proxy
2. Update the docker image reference for that route
3. See that the new binary deployed
4. See that my client continues to work