### PR TITLE
Stop setting memory limit

### DIFF
--- a/http-proxy/main.go
+++ b/http-proxy/main.go
@@ -184,8 +184,6 @@ var (
 	broflakeAddr = flag.String("broflake-addr", "", "Address at which to listen for broflake connections.")
 
 	track = flag.String("track", "", "The track this proxy is running on")
-
-	memLimit = flag.Int64("memlimit", 2000000000, "soft memory limit for the process, defaults to 2 GB")
 )
 
 const (
@@ -356,9 +354,6 @@ func main() {
 		log.Fatalf("unsupported multiplex protocol %v", mux)
 	}
 
-	if *memLimit > 0 {
-		debug.SetMemoryLimit(*memLimit)
-	}
 	memhelper.Track(15*time.Second, 15*time.Second, func(err error) {
 		log.Errorf("error logging memory usage: %v", err)
 	})


### PR DESCRIPTION
We've noticed some runaway proxies spending lots of time in GC and have seen reduced throughput, perhaps that was due to the recent introduction of the memory limit. This backs that out.