### PR TITLE
Require config server auth token flag

### DIFF
--- a/http-proxy/main.go
+++ b/http-proxy/main.go
@@ -275,6 +275,10 @@ func main() {
 		}
 	}()
 
+	if *cfgSvrAuthToken == "" {
+		log.Fatal("Config server auth token is required")
+	}
+
 	if *lampshadeAddr != "" && !*https {
 		log.Fatal("Use of lampshade requires https flag to be true")
 	}


### PR DESCRIPTION
This is a re-do of https://github.com/getlantern/http-proxy-lantern/pull/564, which was reverted by https://github.com/getlantern/http-proxy-lantern/pull/572.

As noted in the original PR, the config server auth token flag is essentially required for the Lantern network to function properly. Otherwise, clients will not be able to request config through their proxies.