### PR TITLE
Record client hello errors, but allow connections to proceed

### DIFF
--- a/tlslistener/clienthelloconn_test.go
+++ b/tlslistener/clienthelloconn_test.go
@@ -59,45 +59,49 @@ func TestAbortOnHello(t *testing.T) {
 				}
 			}()
 
-			cfg := &tls.Config{ServerName: "microsoft.com"}
+			cfg := &tls.Config{ServerName: "microsoft.com", InsecureSkipVerify: true}
 			conn, err := tls.Dial("tcp", l.Addr().String(), cfg)
-			if tc.expectedErr != "" {
-				require.Error(t, err)
-				require.Equal(t, tc.expectedErr, err.Error())
-			} else {
-				require.NoError(t, err)
-				defer conn.Close()
-				require.Equal(t, "microsoft.com", conn.ConnectionState().PeerCertificates[0].Subject.CommonName)
-				req, _ := http.NewRequest("GET", "https://microsoft.com", nil)
-				require.NoError(t, req.Write(conn))
-				resp, err := http.ReadResponse(bufio.NewReader(conn), req)
-				require.NoError(t, err)
-				require.Equal(t, http.StatusMovedPermanently, resp.StatusCode)
-			}
-
-			// Now make sure we can't spoof a session ticket.
-			rawConn, err := net.Dial("tcp", l.Addr().String())
+			// For now, we expect this to work always, even when we're missing a session ticket
+			// See https://github.com/getlantern/engineering/issues/292#issuecomment-1765268377
 			require.NoError(t, err)
-			ucfg := &utls.Config{ServerName: "microsoft.com"}
-			maintainSessionTicketKeyFile("../test/testtickets", "",
-				func(keys [][32]byte) { ucfg.SetSessionTicketKeys(keys) })
-			ss := &utls.ClientSessionState{}
-			ticket := make([]byte, 120)
-			rand.Read(ticket)
-			ss.SetSessionTicket(ticket)
-			ss.SetVers(tls.VersionTLS12)
+			conn.Close()
+			// if tc.expectedErr != "" {
+			// 	require.Error(t, err)
+			// 	require.Equal(t, tc.expectedErr, err.Error())
+			// } else {
+			// 	require.NoError(t, err)
+			// 	defer conn.Close()
+			// 	require.Equal(t, "microsoft.com", conn.ConnectionState().PeerCertificates[0].Subject.CommonName)
+			// 	req, _ := http.NewRequest("GET", "https://microsoft.com", nil)
+			// 	require.NoError(t, req.Write(conn))
+			// 	resp, err := http.ReadResponse(bufio.NewReader(conn), req)
+			// 	require.NoError(t, err)
+			// 	require.Equal(t, http.StatusMovedPermanently, resp.StatusCode)
+			// }
 
-			uconn := utls.UClient(rawConn, ucfg, utls.HelloChrome_Auto)
-			uconn.SetSessionState(ss)
-			err = uconn.Handshake()
-			if tc.expectedErr != "" {
-				require.Error(t, err)
-				require.Equal(t, tc.expectedErr, err.Error(), tc.response.action)
-			} else {
-				require.NoError(t, err)
-				defer conn.Close()
-				require.Equal(t, "microsoft.com", uconn.ConnectionState().PeerCertificates[0].Subject.CommonName)
-			}
+			// // Now make sure we can't spoof a session ticket.
+			// rawConn, err := net.Dial("tcp", l.Addr().String())
+			// require.NoError(t, err)
+			// ucfg := &utls.Config{ServerName: "microsoft.com"}
+			// maintainSessionTicketKeyFile("../test/testtickets", "",
+			// 	func(keys [][32]byte) { ucfg.SetSessionTicketKeys(keys) })
+			// ss := &utls.ClientSessionState{}
+			// ticket := make([]byte, 120)
+			// rand.Read(ticket)
+			// ss.SetSessionTicket(ticket)
+			// ss.SetVers(tls.VersionTLS12)
+
+			// uconn := utls.UClient(rawConn, ucfg, utls.HelloChrome_Auto)
+			// uconn.SetSessionState(ss)
+			// err = uconn.Handshake()
+			// if tc.expectedErr != "" {
+			// 	require.Error(t, err)
+			// 	require.Equal(t, tc.expectedErr, err.Error(), tc.response.action)
+			// } else {
+			// 	require.NoError(t, err)
+			// 	defer conn.Close()
+			// 	require.Equal(t, "microsoft.com", uconn.ConnectionState().PeerCertificates[0].Subject.CommonName)
+			// }
 		})
 	}
 }

--- a/tlslistener/tlslistener.go
+++ b/tlslistener/tlslistener.go
@@ -44,12 +44,7 @@ func Wrap(wrapped net.Listener, keyFile, certFile, sessionTicketKeyFile, firstSe
 
 	expectTicketsFromFile := sessionTicketKeyFile != ""
 	expectTicketsInMemory := sessionTicketKeys != ""
-	// For now, we don't expect tickets if we're only maintaining them in memory.
-	// This will allow clients who are still using session tickets generated with old
-	// disk-based keys to obtain new session tickets without hitting a missing ticket
-	// reaction. See https://github.com/getlantern/engineering/issues/292.
-	// expectTickets := expectTicketsFromFile || expectTicketsInMemory
-	expectTickets := expectTicketsFromFile
+	expectTickets := expectTicketsFromFile || expectTicketsInMemory
 
 	listener := &tlslistener{
 		wrapped:               wrapped,


### PR DESCRIPTION
For getlantern/engineering#292

Every time I reenable RTS, we see a big drop in traffic and see lots of missing ticket reactions being recorded. This PR reenables RTS and records when we would respond as if the ticket is wrong or missing, but then actually allows the connection to proceed successfully. I'm hoping that this will allow us to collect useful data on what's happening (e.g. are there specific client versions that have this problem).