### PR TITLE
Report whether a proxy is legacy or not again

### DIFF
--- a/http_proxy.go
+++ b/http_proxy.go
@@ -723,6 +723,7 @@ func (p *Proxy) buildOTELOpts(endpoint string, includeProxyName bool) *otel.Opts
 		FrontendDC:       p.FrontendDC,
 		ProxyProtocol:    p.ProxyProtocol,
 		IsPro:            p.Pro,
+		Legacy:           strings.HasPrefix(proxyName, "fp-"),
 	}
 	if p.ShadowsocksMultiplexAddr != "" {
 		opts.Addr = p.ShadowsocksMultiplexAddr

--- a/otel/otel.go
+++ b/otel/otel.go
@@ -2,7 +2,6 @@ package otel
 
 import (
 	"context"
-	"strings"
 	"time"
 
 	sdkotel "go.opentelemetry.io/otel"
@@ -40,6 +39,7 @@ type Opts struct {
 	ProxyProtocol    string
 	Addr             string
 	IsPro            bool
+	Legacy           bool
 }
 
 func (opts *Opts) buildResource() *resource.Resource {
@@ -47,6 +47,7 @@ func (opts *Opts) buildResource() *resource.Resource {
 		semconv.ServiceNameKey.String("http-proxy-lantern"),
 		attribute.String("protocol", opts.ProxyProtocol),
 		attribute.Bool("pro", opts.IsPro),
+		attribute.Bool("legacy", opts.Legacy),
 	}
 	// Disable reporting proxy port for Datadog cost reasons
 	// parts := strings.Split(opts.Addr, ":")
@@ -82,10 +83,6 @@ func (opts *Opts) buildResource() *resource.Resource {
 		attributes = append(attributes, attribute.String("frontend.provider", opts.FrontendProvider))
 		attributes = append(attributes, attribute.String("frontend.dc", opts.FrontendDC))
 	}
-	attributes = append(
-		attributes,
-		attribute.Bool("legacy", strings.HasPrefix(opts.ProxyName, "fp-")),
-	)
 	return resource.NewWithAttributes(semconv.SchemaURL, attributes...)
 }
 


### PR DESCRIPTION
We lost the ability to distinguish whether a proxy was `legacy` or not in 411c985d15. (tl;dr, we used the name of the proxy to make the determination, and that commit changed the logic upstream of the code block appending `legacy` as an attribute so that the function doesn't always have the proxy name anymore.) This moves the logic for determining whether a proxy is legacy or l-c a little higher up the call chain, where we still have the proxy's name.