### PR TITLE
make build static to avoid platform-specific issues

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -47,6 +47,8 @@ $(BUILD_DIR):
 $(DIST_DIR):
 	mkdir -p $(DIST_DIR)
 
+# Build with CGO_ENABLED=0 to ensure that we don't have any dependencies on glibc
+# in particular, which can cause issues when running on some Linux versions.
 $(BUILD_DIR)/http-proxy: $(SRCS) | $(BUILD_DIR)
 	GOOS=linux GOARCH=amd64 CGO_ENABLED=0 GOPRIVATE="github.com/getlantern" go build -o $(BUILD_DIR) ./http-proxy
 


### PR DESCRIPTION
our old infrastructure has an older ubuntu without the glibc that Go 1.21 requires, so we need to statically link the binary to avoid trying to load it.