### PR TITLE
Start reporting client platform version data

### DIFF
--- a/common/headers.go
+++ b/common/headers.go
@@ -4,6 +4,7 @@ const (
 	AppHeader               = "X-Lantern-App"
 	KernelArchHeader        = "X-Lantern-KernelArch"
 	PlatformHeader          = "X-Lantern-Platform"
+	PlatformVersionHeader   = "X-Lantern-PlatVer"
 	LibraryVersionHeader    = "X-Lantern-Version"
 	AppVersionHeader        = "X-Lantern-App-Version"
 	DeviceIdHeader          = "X-Lantern-Device-Id"
@@ -24,10 +25,15 @@ const (
 // This standardizes the keys we use for storing data in the request context
 // and for reporting to teleport.
 const (
-	Platform          = "client_platform"
-	KernelArch        = "client_kernel_arch"
-	LibraryVersion    = "client_version"
-	Locale            = "client_locale"
+	Platform        = "client_platform"
+	PlatformVersion = "client_platform_version"
+	KernelArch      = "client_kernel_arch"
+
+	// Note this is the flashlight version.
+	LibraryVersion = "client_version"
+	Locale         = "client_locale"
+
+	// This is the version of the app that's using the library.
 	AppVersion        = "client_app_version"
 	App               = "client_app"
 	DeviceID          = "device_id"

--- a/opsfilter/opsfilter.go
+++ b/opsfilter/opsfilter.go
@@ -75,6 +75,7 @@ func (f *opsfilter) Apply(cs *filters.ConnectionState, req *http.Request, next f
 	addStringHeader(common.KernelArch, common.KernelArchHeader)
 	addStringHeader(common.AppVersion, common.AppVersionHeader)
 	addStringHeader(common.Platform, common.PlatformHeader)
+	addStringHeader(common.PlatformVersion, common.PlatformVersionHeader)
 	addStringHeader(common.App, common.AppHeader)
 	addStringHeader(common.Locale, common.LocaleHeader)
 	addStringHeader(common.TimeZone, common.TimeZoneHeader)

--- a/reporting.go
+++ b/reporting.go
@@ -35,6 +35,7 @@ func newReportingConfig(countryLookup geo.CountryLookup, rc *rclient.Client, ins
 		}
 		// Note - sometimes we're missing the platform and version
 		platform := fromContext(ctx, common.Platform)
+		platformVersion := fromContext(ctx, common.PlatformVersion)
 		appVersion := fromContext(ctx, common.AppVersion)
 		libraryVersion := fromContext(ctx, common.LibraryVersion)
 		app := lowerFromContext(ctx, common.App)
@@ -55,7 +56,7 @@ func newReportingConfig(countryLookup geo.CountryLookup, rc *rclient.Client, ins
 		if hasThrottleSettings {
 			dataCapCohort = throttleSettings.(*throttle.Settings).Label
 		}
-		instrument.ProxiedBytes(context.Background(), deltaStats.SentTotal, deltaStats.RecvTotal, platform, libraryVersion, appVersion, app, locale, dataCapCohort, probingError, client_ip, deviceID, originHost, arch)
+		instrument.ProxiedBytes(context.Background(), deltaStats.SentTotal, deltaStats.RecvTotal, platform, platformVersion, libraryVersion, appVersion, app, locale, dataCapCohort, probingError, client_ip, deviceID, originHost, arch)
 	}
 
 	var reporter listeners.MeasuredReportFN


### PR DESCRIPTION
This will allow us to tell how many clients are running on specific versions of specific operating systems.