### PR TITLE
Count active proxy connections by adding a new metric

### DIFF
--- a/http_proxy.go
+++ b/http_proxy.go
@@ -247,6 +247,10 @@ func (p *Proxy) ListenAndServe(ctx context.Context) error {
 		Filter:                   instrumentedFilter,
 		OKDoesNotWaitForUpstream: !p.ConnectOKWaitsForUpstream,
 		OnError:                  instrumentedErrorHandler,
+		OnActive: func() {
+			// count the connection only when a connection is established and becomes active
+			p.instrument.Connection(ctx)
+		},
 	})
 	stopProxiedBytes := p.configureTeleportProxiedBytes()
 	defer stopProxiedBytes()

--- a/instrument/otelinstrument/otelinstrument.go
+++ b/instrument/otelinstrument/otelinstrument.go
@@ -31,6 +31,7 @@ var (
 	XBQ                                                      metric.Int64Counter
 	Throttling                                               metric.Int64Counter
 	SuspectedProbing                                         metric.Int64Counter
+	Connections                                              metric.Int64Counter
 	DistinctClients1m, DistinctClients10m, DistinctClients1h *distinct.SlidingWindowDistinctCount
 	distinctClients                                          metric.Int64ObservableGauge
 )
@@ -73,6 +74,9 @@ func initialize() error {
 		return err
 	}
 	if SuspectedProbing, err = meter.Int64Counter("proxy.probing.suspected"); err != nil {
+		return err
+	}
+	if Connections, err = meter.Int64Counter("proxy.connections", metric.WithUnit("connections")); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
* Add a proxy connection count metric to count active client connections
* 'active' means that the counter is only incremented after the first successful connection read or write(net.Conn)
* Send data to Teleport via MeterProvider (by default every 60 sec)
* Add a new connection type 'onActiveConn' that wraps all connection types and implements counting logic in Read() and Write()