### PR TITLE
Rename disallowLoopbackForTesting to reflect what it aims for

### DIFF
--- a/tlslistener/clienthelloconn.go
+++ b/tlslistener/clienthelloconn.go
@@ -123,7 +123,7 @@ func Delayed(d time.Duration, r HandshakeReaction) HandshakeReaction {
 	return r2
 }
 
-var disallowLoopbackForTesting bool
+var allowLoopbackForTesting bool
 
 var bufferPool = sync.Pool{
 	New: func() interface{} {
@@ -197,7 +197,7 @@ func (rrc *clientHelloRecordingConn) processHello(info *tls.ClientHelloInfo) (*t
 	sourceIP := rrc.RemoteAddr().(*net.TCPAddr).IP
 	// We allow loopback to generate session states (makesessions) to
 	// distribute to Lantern clients.
-	if !disallowLoopbackForTesting && sourceIP.IsLoopback() {
+	if !allowLoopbackForTesting && sourceIP.IsLoopback() {
 		return nil, nil
 	}
 

--- a/tlslistener/clienthelloconn_test.go
+++ b/tlslistener/clienthelloconn_test.go
@@ -17,7 +17,7 @@ import (
 )
 
 func TestAbortOnHello(t *testing.T) {
-	disallowLoopbackForTesting = true
+	allowLoopbackForTesting = true
 	testCases := []struct {
 		response    HandshakeReaction
 		expectedErr string
@@ -107,7 +107,7 @@ func TestAbortOnHello(t *testing.T) {
 }
 
 func TestSuccess(t *testing.T) {
-	disallowLoopbackForTesting = false
+	allowLoopbackForTesting = false
 	l, _ := net.Listen("tcp", ":0")
 	defer l.Close()
 
@@ -151,9 +151,9 @@ func TestSuccess(t *testing.T) {
 	defer conn.Close()
 
 	// Now disallow loopback for testing, then dial again and make sure session ticket still works
-	disallowLoopbackForTesting = true
+	allowLoopbackForTesting = true
 	defer func() {
-		disallowLoopbackForTesting = false
+		allowLoopbackForTesting = false
 	}()
 
 	conn, err = utls.Dial("tcp", l.Addr().String(), ucfg)


### PR DESCRIPTION
Rename disallowLoopbackForTesting to allowLoopbackForTesting to reflect what it aims for.
Related to [comment](https://github.com/getlantern/engineering/issues/292#issuecomment-2301405389) of https://github.com/getlantern/engineering/issues/292 .