### PR TITLE
adding multiplex support to WATER

### DIFF
--- a/protoListeners.go
+++ b/protoListeners.go
@@ -29,6 +29,6 @@ func getProtoListenersArgs(p *Proxy) []protoListenerArgs {
 			p.ShadowsocksMultiplexAddr,
 			p.wrapMultiplexing(p.listenShadowsocks),
 		},
-		{"water", p.WaterAddr, p.listenWATER},
+		{"water", p.WaterAddr, p.wrapMultiplexing(p.listenWATER)},
 	}
 }


### PR DESCRIPTION
This is a draft PR for testing multiplex support for WATER. With this implementation as is, the proxy is able to receive connections but unable to respond/proxy the information and receives an error.

```
DEBUG cmux: listener.go:88 Error creating multiplexed session, probably just means that the underlying connection was closed: invalid protocol
[WATM reverse v1] read error: errno 6
2024/11/11 19:07:54 worker: unfairWorker: sourceConn.Read: errno 6
[WATM reverse v1] read error: errno 6
```

Update: The error above was only happening because the client (flashlight) wasn't using the multiplex implementation. After enabling at https://github.com/getlantern/flashlight/pull/1439, the connection worked with a few interruptions