### PR TITLE
upgrade go in dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # syntax = docker/dockerfile:1.3
-FROM --platform=$BUILDPLATFORM golang:1.22-alpine as builder
+FROM --platform=$BUILDPLATFORM golang:1.24-alpine as builder
 ARG TARGETOS TARGETARCH
 
 WORKDIR $GOPATH/src/getlantern/http-proxy-lantern/


### PR DESCRIPTION
This is a re-re-attempt to merge https://github.com/getlantern/http-proxy/pull/651/files, Which upgrades go, and incorporates changes to allow unbounded traffic that passes through `http-proxy` to be tracked. This is under a new branch name, because the `docker-push` action failed when the previous branch name contained slashes. 