### PR TITLE
fix(nightly): make .deb/.rpm Version dpkg-valid (digit-leading short commit)

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -40,7 +40,12 @@ builds:
     binary: http-proxy
 
 nightly:
-  version_template: "{{ .ShortCommit }}"
+  # Debian/RPM Version fields must start with a digit, so the bare short commit
+  # (e.g. "dd44277c") is rejected by dpkg with "version number does not start
+  # with digit" whenever the SHA happens to start with a-f. Prefix a digit-
+  # leading stub; the short commit stays in the package file name (see
+  # nfpms.file_name_template) so the cloud-init download URL is unchanged.
+  version_template: "0.0.0+{{ .ShortCommit }}"
   tag_name: nightly
   publish_release: true
   keep_single_release: true
@@ -62,6 +67,11 @@ release:
 nfpms:
   - id: http-proxy
     package_name: "http-proxy-lantern"
+    # Keep the short commit in the package file name (decoupled from the
+    # digit-prefixed Version above) so the asset stays
+    # http-proxy-lantern_<shortcommit>_linux_<arch>.deb — the name the VPS
+    # cloud-init builds its download URL from (bandit_vps_http_proxy_default_short_tag).
+    file_name_template: "http-proxy-lantern_{{ .ShortCommit }}_linux_{{ .Arch }}"
     formats:
       - deb
       - rpm


### PR DESCRIPTION
## Problem

Nightly `.deb`/`.rpm` packages set their **Version field to the bare short commit** (`.goreleaser.yaml`: `version_template: "{{ .ShortCommit }}"`). Debian/RPM require the Version to start with a digit, so any nightly whose short SHA starts with `a`–`f` (~6/16 of commits) produces a package dpkg refuses to install:

```
dpkg: error processing archive .../http-proxy-lantern dd44277c [14.9 MB] (--unpack):
 parsing file '/var/lib/dpkg/tmp.ci/control' near line 2 package 'http-proxy-lantern':
 'Version' field value 'dd44277c': version number does not start with digit
E: Sub-process /usr/bin/dpkg returned an error code (1)
```

On the bandit VPS fleet this aborts cloud-init's package-install step (`cc_scripts_user … Runparts: 1 failures`), so http-proxy never installs, the route never reaches `running`/gets a public address, and the provisioner retries the box forever. It went unnoticed because previous nightly tags happened to start with a digit (e.g. `7f088dcf`); pointing the fleet at `dd44277c` surfaced it and stalled all new http-proxy provisions.

## Fix

- `version_template: "0.0.0+{{ .ShortCommit }}"` — digit-leading, valid for both dpkg and rpm (`0.0.0+dd44277c`).
- Pin `nfpms.file_name_template` to `http-proxy-lantern_{{ .ShortCommit }}_linux_{{ .Arch }}` so the published asset name is **unchanged** (`http-proxy-lantern_<shortcommit>_linux_<arch>.deb`). The VPS cloud-init builds its download URL from `bandit_vps_http_proxy_default_short_tag` (alnum short commit), so decoupling the file name from the Version keeps that workflow working with no change in lantern-cloud.

`goreleaser check` passes.

## After merge / deploy

Once a nightly is built from this fix, point the fleet at the new short commit:
`lc settings update --name bandit_vps_http_proxy_default_short_tag --value '"<newshortcommit>"' --overwrite`. With this change any short commit (digit- or letter-leading) installs cleanly.

Related: getlantern/engineering#3630 (http-proxy hot-swap gap — separate issue). Surfaced while rolling out the keepcurrent memory fix (#671).