### PR TITLE
build: bump keepcurrent for fileSource pre-size fix (follow-up)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -134,7 +134,7 @@ require (
 	github.com/getlantern/hex v0.0.0-20220104173244-ad7e4b9194dc // indirect
 	github.com/getlantern/hidden v0.0.0-20220104173330-f221c5a24770 // indirect
 	github.com/getlantern/kcp-go/v5 v5.0.0-20220503142114-f0c1cd6e1b54 // indirect
-	github.com/getlantern/keepcurrent v0.0.0-20260616114120-898f32b9cb49 // indirect
+	github.com/getlantern/keepcurrent v0.0.0-20260616120552-f204338b01a3 // indirect
 	github.com/getlantern/mtime v0.0.0-20200417132445-23682092d1f7 // indirect
 	github.com/getlantern/preconn v1.0.0 // indirect
 	github.com/getlantern/telemetry v0.0.0-20250606052628-8960164ec1f5 // indirect

--- a/go.mod
+++ b/go.mod
@@ -134,7 +134,7 @@ require (
 	github.com/getlantern/hex v0.0.0-20220104173244-ad7e4b9194dc // indirect
 	github.com/getlantern/hidden v0.0.0-20220104173330-f221c5a24770 // indirect
 	github.com/getlantern/kcp-go/v5 v5.0.0-20220503142114-f0c1cd6e1b54 // indirect
-	github.com/getlantern/keepcurrent v0.0.0-20260616091602-0364abd4ecd2 // indirect
+	github.com/getlantern/keepcurrent v0.0.0-20260616114120-898f32b9cb49 // indirect
 	github.com/getlantern/mtime v0.0.0-20200417132445-23682092d1f7 // indirect
 	github.com/getlantern/preconn v1.0.0 // indirect
 	github.com/getlantern/telemetry v0.0.0-20250606052628-8960164ec1f5 // indirect

--- a/go.sum
+++ b/go.sum
@@ -276,8 +276,8 @@ github.com/getlantern/kcp-go/v5 v5.0.0-20220503142114-f0c1cd6e1b54 h1:JqIiaDpL6C
 github.com/getlantern/kcp-go/v5 v5.0.0-20220503142114-f0c1cd6e1b54/go.mod h1:KFBWdR0PdEQK0JtGcE1lhAoYFVTRxWDFfYBARPb0t9Q=
 github.com/getlantern/kcpwrapper v0.0.0-20230327091313-c12d7c17c6de h1:RS4Tx7aVExrAXsgvrXSln9iQ5HZNPpvHjJGM/MQH8ZE=
 github.com/getlantern/kcpwrapper v0.0.0-20230327091313-c12d7c17c6de/go.mod h1:UVPVk1fNbqBceE4i+x/qbNxUNQ7gMACdOukoIbXM9jc=
-github.com/getlantern/keepcurrent v0.0.0-20260616114120-898f32b9cb49 h1:kmNPo47R7QMtE+lLIuSjDXGb1JQwzOOizJJ7ra6REE4=
-github.com/getlantern/keepcurrent v0.0.0-20260616114120-898f32b9cb49/go.mod h1:ag5g9aWUw2FJcX5RVRpJ9EBQBy5yJuy2WXDouIn/m4w=
+github.com/getlantern/keepcurrent v0.0.0-20260616120552-f204338b01a3 h1:YPBbuyvdWv+YvXDqADVwjxM0DyABg2x4UgLVKU9McKI=
+github.com/getlantern/keepcurrent v0.0.0-20260616120552-f204338b01a3/go.mod h1:ag5g9aWUw2FJcX5RVRpJ9EBQBy5yJuy2WXDouIn/m4w=
 github.com/getlantern/keyman v0.0.0-20180207174507-f55e7280e93a/go.mod h1:FMf0g72BHs14jVcD8i8ubEk4sMB6JdidBn67d44i3ws=
 github.com/getlantern/keyman v0.0.0-20230503155501-4e864ca2175b h1:iyEuk8ARQC9HfraqC4r3leBhU55R1TV7bAiyPYE54kA=
 github.com/getlantern/keyman v0.0.0-20230503155501-4e864ca2175b/go.mod h1:ZJ+yDaZkJ/JU9j7EQa3UUh6ouedrNDDLA5OiowS1Iuk=

--- a/go.sum
+++ b/go.sum
@@ -276,8 +276,8 @@ github.com/getlantern/kcp-go/v5 v5.0.0-20220503142114-f0c1cd6e1b54 h1:JqIiaDpL6C
 github.com/getlantern/kcp-go/v5 v5.0.0-20220503142114-f0c1cd6e1b54/go.mod h1:KFBWdR0PdEQK0JtGcE1lhAoYFVTRxWDFfYBARPb0t9Q=
 github.com/getlantern/kcpwrapper v0.0.0-20230327091313-c12d7c17c6de h1:RS4Tx7aVExrAXsgvrXSln9iQ5HZNPpvHjJGM/MQH8ZE=
 github.com/getlantern/kcpwrapper v0.0.0-20230327091313-c12d7c17c6de/go.mod h1:UVPVk1fNbqBceE4i+x/qbNxUNQ7gMACdOukoIbXM9jc=
-github.com/getlantern/keepcurrent v0.0.0-20260616091602-0364abd4ecd2 h1:ZNkfDGgqtKrX2CEs/SryCx31Qe8GEu2a+HAmeyX2UU4=
-github.com/getlantern/keepcurrent v0.0.0-20260616091602-0364abd4ecd2/go.mod h1:ag5g9aWUw2FJcX5RVRpJ9EBQBy5yJuy2WXDouIn/m4w=
+github.com/getlantern/keepcurrent v0.0.0-20260616114120-898f32b9cb49 h1:kmNPo47R7QMtE+lLIuSjDXGb1JQwzOOizJJ7ra6REE4=
+github.com/getlantern/keepcurrent v0.0.0-20260616114120-898f32b9cb49/go.mod h1:ag5g9aWUw2FJcX5RVRpJ9EBQBy5yJuy2WXDouIn/m4w=
 github.com/getlantern/keyman v0.0.0-20180207174507-f55e7280e93a/go.mod h1:FMf0g72BHs14jVcD8i8ubEk4sMB6JdidBn67d44i3ws=
 github.com/getlantern/keyman v0.0.0-20230503155501-4e864ca2175b h1:iyEuk8ARQC9HfraqC4r3leBhU55R1TV7bAiyPYE54kA=
 github.com/getlantern/keyman v0.0.0-20230503155501-4e864ca2175b/go.mod h1:ZJ+yDaZkJ/JU9j7EQa3UUh6ouedrNDDLA5OiowS1Iuk=


### PR DESCRIPTION
Follow-up to #671. Pulls in [keepcurrent#10](https://github.com/getlantern/keepcurrent/pull/10).

## Why

#671 deployed the keepcurrent memory fix, but pprof on the rolled-out fleet showed a residual `io.ReadAll` doubling churn from `geo`'s startup `InitFrom(FromFile(...))` read of the cached ~75MB MaxMind mmdb — keepcurrent's `fileSource` was the one source #9 didn't make size-aware. keepcurrent#10 closes that.

## What

`go get keepcurrent@<#10> && go mod tidy`. keepcurrent stays indirect; no first-party code change. Build is clean (geo-consuming packages incl. the `http-proxy` command compile; only the pre-existing `anacrolix/go-libutp` cgo issue, unrelated).

⚠️ **Merge order:** pinned to the keepcurrent **PR-head** commit. After keepcurrent#10 squash-merges to main, re-pin to the merged commit (`go get github.com/getlantern/keepcurrent@<main-sha> && go mod tidy`) before merging this. See the rollout handoff.