### PR TITLE
metrics: emit goodput `track` as a point attribute so the bandit evaluator can slice it

### DIFF
--- a/http_proxy.go
+++ b/http_proxy.go
@@ -242,6 +242,7 @@ func (p *Proxy) ListenAndServe(ctx context.Context) error {
 		p.CountryLookup,
 		p.ISPLookup,
 		p.ProxyName,
+		p.Track,
 	)
 	if err != nil {
 		return errors.New("Unable to configure instrumentation: %v", err)

--- a/instrument/goodput_test.go
+++ b/instrument/goodput_test.go
@@ -28,7 +28,7 @@ func newGoodputInstrument(t *testing.T) (*defaultInstrument, *sdkmetric.ManualRe
 	provider := sdkmetric.NewMeterProvider(sdkmetric.WithReader(reader))
 	sdkotel.SetMeterProvider(provider)
 
-	ins, err := NewDefault(geo.NoLookup{}, &mockISPLookup{}, "test-proxy")
+	ins, err := NewDefault(geo.NoLookup{}, &mockISPLookup{}, "test-proxy", "test-track")
 	require.NoError(t, err)
 	return ins, reader
 }
@@ -53,6 +53,10 @@ func TestSessionGoodput(t *testing.T) {
 
 	attrs := extractHistogramAttrs(rm, "proxy.session.goodput")
 	assert.Equal(t, "receive", attrs["network.io.direction"])
+	// track must be a point attribute keyed "track" so the bandit evaluator can
+	// slice goodput per (track, country); it queries this label, not the
+	// "proxy.track" resource attribute.
+	assert.Equal(t, "test-track", attrs["track"], "goodput sample should carry the track point attribute")
 	// The country point attribute must always be present (empty here, since the
 	// test uses geo.NoLookup) so the metric stays sliceable by country.
 	_, hasCountry := attrs["geo.country.iso_code"]

--- a/instrument/instrument.go
+++ b/instrument/instrument.go
@@ -112,9 +112,10 @@ type defaultInstrument struct {
 	originStats   map[originDetails]*usage
 	statsMx       sync.Mutex
 	proxyName     string
+	track         string
 }
 
-func NewDefault(countryLookup geo.CountryLookup, ispLookup geo.ISPLookup, proxyName string) (*defaultInstrument, error) {
+func NewDefault(countryLookup geo.CountryLookup, ispLookup geo.ISPLookup, proxyName, track string) (*defaultInstrument, error) {
 	if err := otelinstrument.Initialize(); err != nil {
 		return nil, err
 	}
@@ -127,6 +128,7 @@ func NewDefault(countryLookup geo.CountryLookup, ispLookup geo.ISPLookup, proxyN
 		clientStats:   make(map[clientDetails]*usage),
 		originStats:   make(map[originDetails]*usage),
 		proxyName:     proxyName,
+		track:         track,
 	}
 
 	return p, nil
@@ -320,8 +322,14 @@ func (ins *defaultInstrument) ProxiedBytes(ctx context.Context, sent, recv int, 
 // periods, so this is a floor on true transfer speed — but both arms of a
 // bandit experiment are measured identically, so it's a fair relative signal,
 // and the byte floor filters the worst idle-dominated noise. No device_id tag
-// (cardinality); track and cloud.region come from resource attributes, leaving
-// geo.country.iso_code as the only point attribute the evaluator strata need.
+// (cardinality). track is emitted as a point attribute keyed "track": the bandit
+// evaluator slices goodput per (track, country) and queries that low-cardinality
+// point attribute (matching lantern-box). The resource also carries the track as
+// semconv.ProxyTrackKey ("proxy.track"), but the metrics pipeline doesn't expose
+// resource attributes as queryable labels, so the evaluator's "track" filter
+// can't see it — hence the explicit point attribute. cloud.region is left to the
+// resource: the strata are (track, country) only and a challenger is pinned to
+// one DC, so region would add cardinality without decision value.
 func (ins *defaultInstrument) SessionGoodput(ctx context.Context, recvBytes int, duration time.Duration, clientIP net.IP) {
 	if recvBytes < goodputMinBytes || duration <= 0 {
 		return
@@ -330,6 +338,7 @@ func (ins *defaultInstrument) SessionGoodput(ctx context.Context, recvBytes int,
 	country := ins.countryLookup.CountryCode(clientIP)
 	otelinstrument.SessionGoodput.Record(ctx, goodput,
 		metric.WithAttributes(
+			attribute.String("track", ins.track),
 			semconv.GeoCountryISOCodeKey.String(country),
 			semconv.NetworkIODirectionKey.String("receive"),
 		))

--- a/instrument/otelinstrument/otelinstrument.go
+++ b/instrument/otelinstrument/otelinstrument.go
@@ -82,10 +82,10 @@ func initialize() error {
 	}
 	// Per-session download goodput (received bytes per second of connection
 	// lifetime), recorded once at connection close for sessions that moved at
-	// least goodputMinBytes. Sliceable by track (resource attr) × cloud.region
-	// (resource attr) × geo.country.iso_code (point attr) so the bandit
-	// experiment evaluator can compare a challenger track's median goodput
-	// against the incumbent's. Unit "bytes/s" follows proxy.io's "bytes"
+	// least goodputMinBytes. Sliceable by track × geo.country.iso_code (both
+	// point attrs) so the bandit experiment evaluator can compare a challenger
+	// track's median goodput against the incumbent's per market; cloud.region
+	// stays a resource attr. Unit "bytes/s" follows proxy.io's "bytes"
 	// spelling for consistency within this package's metrics.
 	if SessionGoodput, err = meter.Float64Histogram("proxy.session.goodput",
 		metric.WithUnit("bytes/s"),


### PR DESCRIPTION
## What

`proxy.session.goodput` now carries `track` as a **point (datapoint) attribute** keyed `track`, in addition to the existing `proxy.track` resource attribute.

## Why

The goodput histogram (#674) tagged `track` only via the OTEL **resource** (`semconv.ProxyTrackKey = "proxy.track"`). SigNoz's metrics pipeline doesn't expose resource attributes as queryable metric labels, and the bandit experiment evaluator (lantern-cloud `cmd/api/experiment/signoz.go`) groups and filters goodput by the **point** attribute literally named `track` — the way lantern-box emits it.

Result: the evaluator's `track IN [challenger, control]` query matched sing-box/lantern-box tracks but **never** http-proxy tracks. Verified on prod:
- `track = 'hysteria2-oci-free-vps'` (sing-box) → goodput data
- `track = 'blastoise-vps'` (busy http-proxy incumbent, 21 routes, 24h) → **0**; all http-proxy goodput sat in an untagged `track=""` bucket.

So every http-proxy challenger **and** http-proxy control arm read 0 goodput, and no http-proxy-backed bandit experiment could ever reach a verdict (it would hold until the 14-day max-gathering cutoff and retire inconclusive). This blocks the eng#3651 market-pivot experiments, whose challengers are http-proxy (`tls_*`) tracks.

## Change

- `instrument.SessionGoodput` emits `attribute.String("track", ins.track)` as a point attribute alongside `geo.country.iso_code` and `network.io.direction`.
- `track` is threaded into `defaultInstrument` via `NewDefault` from the proxy's existing `-track` flag (`p.Track`).
- The resource still carries `proxy.track` for all other signals — unchanged.
- `cloud.region` is intentionally left a resource attribute: the evaluator's strata are `(track, country)` and a challenger is pinned to one DC, so region as a point attr would add cardinality with no decision value.

## Tests

`go build ./instrument/...` + `go vet` clean; `go test ./instrument/ -run TestSessionGoodput` passes. Extended `TestSessionGoodput` to assert the `track` point attribute is present and equals the configured track. (Repo-wide `go build ./...` fails only on the pre-existing `go-libutp` CGO/compiler incompatibility, unrelated to this change.)

## Rollout note

After merge: rebuild the http-proxy image and bump `bandit_vps_http_proxy_default_short_tag` in lantern-cloud so new VPS provisions emit track-tagged goodput. Existing experiment challengers were provisioned on the prior image; they'll pick up the new image on VPS autoreplace/recreate (or just let the current 4 retire and let post-rollout experiments be the measurable ones).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added tracking information to session goodput metrics, improving visibility into proxy activity reporting.
  * Metrics now include the proxy’s track label alongside existing location details.

* **Tests**
  * Updated metric tests to verify the new track label is included in emitted goodput data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->