### PR TITLE
Exempt legacy API hosts from local-address filter

### DIFF
--- a/http-proxy/main.go
+++ b/http-proxy/main.go
@@ -97,13 +97,9 @@ var (
 	banditCallbackURL   = flag.String("banditcallbackurl", "", "Full URL of the /v1/bandit/callback endpoint")
 	banditCallbackTTL   = flag.Duration("banditcallbackttl", 60*time.Second, "Per-device dedup window and heartbeat cadence for bandit callback emission. The API's absence-reaper expects a callback within ArmCallbackHeartbeatWindow (~90s) of the previous one; values much smaller than that just amplify callback traffic, values larger risk false-positive negative rewards on idle clients.")
 
-	// Hostnames exempted from the BlockLocal local-address filter. Legacy
-	// pre-9.x clients still reach api.getiantem.org/geo.getiantem.org
-	// directly; those front through Cloudflare/CloudFront and don't need
-	// DNS-rebind protection the way an arbitrary CONNECT target does.
-	// Defaulted here (rather than left empty) so this binary restores
-	// legacy purchases on its own; the provisioner can override it.
-	legacyAPIHosts = flag.String("legacyapihosts", "api.getiantem.org,geo.getiantem.org", "Comma-separated hostnames exempted from the BlockLocal private/global-unicast check")
+	// Defaults cover the legacy hosts so this fixes itself on upgrade;
+	// the provisioner can still override it later. See eng#3695.
+	legacyAPIHosts = flag.String("legacyapihosts", "api.getiantem.org,geo.getiantem.org", "Comma-separated hostnames exempted from the BlockLocal filter")
 
 	throttleRefreshInterval = flag.Duration("throttlerefresh", throttle.DefaultRefreshInterval, "Specifies how frequently to refresh throttling configuration from redis. Defaults to 5 minutes.")
 

--- a/http-proxy/main.go
+++ b/http-proxy/main.go
@@ -97,6 +97,14 @@ var (
 	banditCallbackURL   = flag.String("banditcallbackurl", "", "Full URL of the /v1/bandit/callback endpoint")
 	banditCallbackTTL   = flag.Duration("banditcallbackttl", 60*time.Second, "Per-device dedup window and heartbeat cadence for bandit callback emission. The API's absence-reaper expects a callback within ArmCallbackHeartbeatWindow (~90s) of the previous one; values much smaller than that just amplify callback traffic, values larger risk false-positive negative rewards on idle clients.")
 
+	// Hostnames exempted from the BlockLocal local-address filter. Legacy
+	// pre-9.x clients still reach api.getiantem.org/geo.getiantem.org
+	// directly; those front through Cloudflare/CloudFront and don't need
+	// DNS-rebind protection the way an arbitrary CONNECT target does.
+	// Defaulted here (rather than left empty) so this binary restores
+	// legacy purchases on its own; the provisioner can override it.
+	legacyAPIHosts = flag.String("legacyapihosts", "api.getiantem.org,geo.getiantem.org", "Comma-separated hostnames exempted from the BlockLocal private/global-unicast check")
+
 	throttleRefreshInterval = flag.Duration("throttlerefresh", throttle.DefaultRefreshInterval, "Specifies how frequently to refresh throttling configuration from redis. Defaults to 5 minutes.")
 
 	enableMultipath = flag.Bool("enablemultipath", false, "Enable multipath. Only clients support multipath can communicate with it.")
@@ -406,6 +414,7 @@ func main() {
 		BanditCallbackToken:                *banditCallbackToken,
 		BanditCallbackURL:                  *banditCallbackURL,
 		BanditCallbackTTL:                  *banditCallbackTTL,
+		LegacyAPIHosts:                     *legacyAPIHosts,
 		EnableMultipath:                    *enableMultipath,
 		ThrottleRefreshInterval:            *throttleRefreshInterval,
 		TracesSampleRate:                   *tracesSampleRate,

--- a/http_proxy.go
+++ b/http_proxy.go
@@ -188,16 +188,9 @@ type Proxy struct {
 	BanditCallbackTTL     time.Duration
 	banditCallbackEmitter *banditcallback.Emitter
 
-	// LegacyAPIHosts is a comma-separated list of hostnames that
-	// BlockLocal must let through without its usual private/global-unicast
-	// check. It exists for legacy pre-9.x clients that still talk to
-	// api.getiantem.org/geo.getiantem.org directly (rather than through the
-	// current API host): those domains front through Cloudflare/CloudFront,
-	// so they resolve fine everywhere else, but nothing about them requires
-	// DNS-rebind protection the way an arbitrary user-supplied CONNECT
-	// target does. Defaults to the known legacy hosts so upgrading this
-	// binary alone restores legacy purchases; the provisioner can override
-	// it to add/drop hosts without another release.
+	// LegacyAPIHosts are extra hostnames exempted from BlockLocal, comma
+	// separated. Used for legacy pre-9.x clients hitting api.getiantem.org
+	// directly (see eng#3695).
 	LegacyAPIHosts string
 
 	MultiplexProtocol             string

--- a/http_proxy.go
+++ b/http_proxy.go
@@ -188,6 +188,18 @@ type Proxy struct {
 	BanditCallbackTTL     time.Duration
 	banditCallbackEmitter *banditcallback.Emitter
 
+	// LegacyAPIHosts is a comma-separated list of hostnames that
+	// BlockLocal must let through without its usual private/global-unicast
+	// check. It exists for legacy pre-9.x clients that still talk to
+	// api.getiantem.org/geo.getiantem.org directly (rather than through the
+	// current API host): those domains front through Cloudflare/CloudFront,
+	// so they resolve fine everywhere else, but nothing about them requires
+	// DNS-rebind protection the way an arbitrary user-supplied CONNECT
+	// target does. Defaults to the known legacy hosts so upgrading this
+	// binary alone restores legacy purchases; the provisioner can override
+	// it to add/drop hosts without another release.
+	LegacyAPIHosts string
+
 	MultiplexProtocol             string
 	SmuxVersion                   int
 	SmuxMaxFrameSize              int
@@ -591,6 +603,7 @@ func (p *Proxy) createFilterChain(bl *blacklist.Blacklist) (filters.Chain, proxy
 		if p.PacketForwardAddr != "" {
 			allowedLocalAddrs = append(allowedLocalAddrs, p.PacketForwardAddr)
 		}
+		allowedLocalAddrs = append(allowedLocalAddrs, p.legacyAPIHostExceptions()...)
 		filterChain = filterChain.Append(proxyfilters.BlockLocal(allowedLocalAddrs, &proxyfilters.Resolver{}))
 	}
 	instrumentedProxyPingFilter, err := p.instrument.WrapFilter("proxy_http_ping", ping.New(0))
@@ -741,6 +754,20 @@ func (p *Proxy) loadThrottleConfig() {
 		log.Debug("Not loading throttle config")
 		return
 	}
+}
+
+func (p *Proxy) legacyAPIHostExceptions() []string {
+	if p.LegacyAPIHosts == "" {
+		return nil
+	}
+	var hosts []string
+	for _, h := range strings.Split(p.LegacyAPIHosts, ",") {
+		h = strings.TrimSpace(h)
+		if h != "" {
+			hosts = append(hosts, h)
+		}
+	}
+	return hosts
 }
 
 func (p *Proxy) allowedTunnelPorts() []int {

--- a/proxyfilters/blocklocal.go
+++ b/proxyfilters/blocklocal.go
@@ -33,14 +33,18 @@ func BlockLocal(exceptions []string, r resolver) filters.Filter {
 	}
 
 	return filters.FilterFunc(func(cs *filters.ConnectionState, req *http.Request, next filters.Next) (*http.Response, *filters.ConnectionState, error) {
-		if isException(req.URL.Host) {
-			return next(cs, req)
-		}
-
 		host, port, err := net.SplitHostPort(req.URL.Host)
 		if err != nil {
 			// host didn't have a port, thus splitting didn't work
 			host = req.URL.Host
+		}
+
+		// Check both the raw Host (so port-scoped exceptions like
+		// "127.0.0.1:7300" only match that exact address) and the bare
+		// hostname (so a hostname exception matches regardless of
+		// whether the client happened to include the default port).
+		if isException(req.URL.Host) || isException(host) {
+			return next(cs, req)
 		}
 
 		ipAddr, err := r.ResolveIPAddr("ip", host)

--- a/proxyfilters/blocklocal.go
+++ b/proxyfilters/blocklocal.go
@@ -39,10 +39,8 @@ func BlockLocal(exceptions []string, r resolver) filters.Filter {
 			host = req.URL.Host
 		}
 
-		// Check both the raw Host (so port-scoped exceptions like
-		// "127.0.0.1:7300" only match that exact address) and the bare
-		// hostname (so a hostname exception matches regardless of
-		// whether the client happened to include the default port).
+		// Check the bare host too, so a hostname exception matches with
+		// or without the default port.
 		if isException(req.URL.Host) || isException(host) {
 			return next(cs, req)
 		}

--- a/proxyfilters/blocklocal_test.go
+++ b/proxyfilters/blocklocal_test.go
@@ -40,6 +40,14 @@ func TestBlockLocalExceptionWithPort(t *testing.T) {
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 }
 
+func TestBlockLocalExceptionIgnoresDefaultPort(t *testing.T) {
+	// A hostname exception (no port) must match regardless of whether the
+	// client's request explicitly includes the default port, since legacy
+	// clients are inconsistent about this (eng#3695).
+	_, resp := doTestBlockLocal(t, []string{"api.getiantem.org"}, "http://api.getiantem.org:80/plans-v4", &testResolver{104, 18, 3, 252})
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+}
+
 func TestBlockLocalNotLocal(t *testing.T) {
 	modifiedReq, resp := doTestBlockLocal(t, []string{"localhost"}, "http://example.com/index.html", &testResolver{93, 184, 215, 16})
 	assert.Equal(t, http.StatusOK, resp.StatusCode)

--- a/proxyfilters/blocklocal_test.go
+++ b/proxyfilters/blocklocal_test.go
@@ -41,9 +41,7 @@ func TestBlockLocalExceptionWithPort(t *testing.T) {
 }
 
 func TestBlockLocalExceptionIgnoresDefaultPort(t *testing.T) {
-	// A hostname exception (no port) must match regardless of whether the
-	// client's request explicitly includes the default port, since legacy
-	// clients are inconsistent about this (eng#3695).
+	// eng#3695: exception should match even with the port included.
 	_, resp := doTestBlockLocal(t, []string{"api.getiantem.org"}, "http://api.getiantem.org:80/plans-v4", &testResolver{104, 18, 3, 252})
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 }


### PR DESCRIPTION
Legacy pre-9.x clients still hit api.getiantem.org/geo.getiantem.org directly. Since the phost fleet was retired, that traffic now goes through VPS proxies, whose BlockLocal filter has no way to allowlist a host — it just rejects them with a 403

This adds a -legacyapihosts flag (default: the two hosts above) so the proxy exempts them from the filter. Also fixed BlockLocal to match on hostname alone, since legacy clients don't consistently include the port.





<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for configuring legacy API hostnames that can bypass local-address blocking.
  * Added a command-line option for specifying additional exempted hosts.

* **Bug Fixes**
  * Host exceptions now work correctly when requests include a port, such as `:80`.
  * Hostname matching handles both full host-and-port values and bare hostnames.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->