### PR TITLE
release: publish immutable per-build nightly releases (eng#3697)

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -46,9 +46,19 @@ nightly:
   # leading stub; the short commit stays in the package file name (see
   # nfpms.file_name_template) so the cloud-init download URL is unchanged.
   version_template: "0.0.0+{{ .ShortCommit }}"
-  tag_name: nightly
+  # Immutable per-build releases: each merge to main publishes its own release
+  # "nightly-<shortcommit>" whose assets are never overwritten, instead of a
+  # single mutable "nightly" release that a rebuild would delete out from under
+  # any VPS still pinned to the previous build. That deletion 404'd http-proxy
+  # VPS provisioning fleet-wide (getlantern/engineering#3697). The lantern-cloud
+  # provisioner composes the download URL as
+  # .../releases/download/nightly-<short>/http-proxy-lantern_<short>_linux_<arch>.deb.
+  tag_name: "nightly-{{ .ShortCommit }}"
   publish_release: true
-  keep_single_release: true
+  # Keep every build's release (was true). With a unique per-build tag_name
+  # there is nothing for keep_single_release to prune anyway; false makes the
+  # keep-all intent explicit.
+  keep_single_release: false
 
 archives:
   - formats: ["tar.gz"]

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -44,14 +44,17 @@ nightly:
   # (e.g. "dd44277c") is rejected by dpkg with "version number does not start
   # with digit" whenever the SHA happens to start with a-f. Prefix a digit-
   # leading stub; the short commit stays in the package file name (see
-  # nfpms.file_name_template) so the cloud-init download URL is unchanged.
+  # nfpms.file_name_template) so the asset filename is unchanged (the release
+  # tag, and therefore the URL path, does change — see tag_name below).
   version_template: "0.0.0+{{ .ShortCommit }}"
-  # Immutable per-build releases: each merge to main publishes its own release
-  # "nightly-<shortcommit>" whose assets are never overwritten, instead of a
-  # single mutable "nightly" release that a rebuild would delete out from under
-  # any VPS still pinned to the previous build. That deletion 404'd http-proxy
-  # VPS provisioning fleet-wide (getlantern/engineering#3697). The lantern-cloud
-  # provisioner composes the download URL as
+  # Immutable per-commit releases: each merge to main publishes its own release
+  # "nightly-<shortcommit>", so a later merge (a different commit) can no longer
+  # delete the assets of a build a VPS is still pinned to — unlike the single
+  # mutable "nightly" release, whose rebuild-on-every-merge deletion 404'd
+  # http-proxy VPS provisioning fleet-wide (getlantern/engineering#3697). (A
+  # workflow_dispatch re-run of the *same* commit reuses the tag and replaces
+  # its own identical assets; that's harmless.) The lantern-cloud provisioner
+  # composes the download URL as
   # .../releases/download/nightly-<short>/http-proxy-lantern_<short>_linux_<arch>.deb.
   tag_name: "nightly-{{ .ShortCommit }}"
   publish_release: true


### PR DESCRIPTION
## Summary

Make the `nightly` release process publish **immutable per-build releases** instead of overwriting one mutable `nightly` release. Addresses the root cause of the http-proxy VPS provisioning outage class in getlantern/engineering#3697.

Today goreleaser (`--nightly`, `keep_single_release: true`, `tag_name: nightly`) replaces the single `nightly` release's assets on every build. http-proxy VPS pin a specific short-SHA `.deb` at provision time, so each merge to `main` **deletes the asset the fleet is pinned to** → new VPS provisions 404 and stall fleet-wide until an operator re-promotes the build (incident 2026-07-16: ~156 routes stuck, 0 reached `running` for ~20h).

## Change

```diff
 nightly:
   version_template: "0.0.0+{{ .ShortCommit }}"
-  tag_name: nightly
+  tag_name: "nightly-{{ .ShortCommit }}"
   publish_release: true
-  keep_single_release: true
+  keep_single_release: false
```

- Each merge to `main` now publishes its own release `nightly-<shortcommit>` whose assets are never overwritten — a promoted build's `.deb` survives every later merge.
- The `nfpms` asset filename is unchanged, so the download URL becomes `.../releases/download/nightly-<short>/http-proxy-lantern_<short>_linux_<arch>.deb`.
- `keep_single_release: false` keeps every build's release (with a unique per-build `tag_name` there is nothing for it to prune anyway; `false` makes the keep-all intent explicit).

## Notes

- Templated `tag_name` requires goreleaser ≥ v2.16; the release workflow uses `version: "~> 2"`, which resolves well past that.
- `release.yaml` triggers on `push` to `main` only (not tags), so the new per-build tags don't re-trigger the workflow.
- The Docker image path (`push.yml` → Artifact Registry) is untouched.
- Releases accumulate one per merge (kept forever, by design — safest for the immutability guarantee). Dated pruning can be added later once the consumer's auto-poller guarantees the fleet never pins an ancient build.

## Consumer / rollout

Consumed by getlantern/lantern-cloud#2985 (composes the immutable `nightly-<short>` URL + adds an auto-poller). **Merge this first** so the first `nightly-<mergeShort>` release exists before that change is deployed. See getlantern/engineering#3697 for the coordinated rollout.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Nightly releases now receive unique build-specific tags, making each build easier to identify and retrieve.
  * Previous nightly releases are retained instead of being overwritten by newer builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->