### PR TITLE
metrics: emit session goodput for all sessions, not just >=1MB (fix false experiment starvation)

### DIFF
--- a/instrument/goodput_test.go
+++ b/instrument/goodput_test.go
@@ -11,6 +11,7 @@ import (
 	"go.opentelemetry.io/otel/sdk/metric/metricdata"
 
 	"github.com/getlantern/geo"
+	"github.com/getlantern/http-proxy-lantern/v2/instrument/otelinstrument"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -28,25 +29,31 @@ func newGoodputInstrument(t *testing.T) (*defaultInstrument, *sdkmetric.ManualRe
 	provider := sdkmetric.NewMeterProvider(sdkmetric.WithReader(reader))
 	sdkotel.SetMeterProvider(provider)
 
+	// Rebind otelinstrument's instruments to this provider's reader. Initialize()
+	// is sync.Once-guarded, so without this reset only the first goodput test to
+	// run in the process would observe recorded metrics (the rest would record
+	// into the first test's now-discarded reader).
+	require.NoError(t, otelinstrument.ResetForTest())
+
 	ins, err := NewDefault(geo.NoLookup{}, &mockISPLookup{}, "test-proxy", "test-track")
 	require.NoError(t, err)
 	return ins, reader
 }
 
-// TestSessionGoodput verifies the per-session download goodput histogram is
-// recorded once for a session that moved >= goodputMinBytes, with the value
-// ~= received bytes / connection seconds and a receive direction tag.
+// TestSessionGoodput verifies the per-session goodput histogram is recorded
+// once for a session that moved data, with the value ~= received bytes /
+// connection seconds and a receive direction tag.
 func TestSessionGoodput(t *testing.T) {
 	ins, reader := newGoodputInstrument(t)
 
-	const recv = 1_100_000 // above the 1MB goodput threshold
+	const recv = 1_100_000
 	ins.SessionGoodput(context.Background(), recv, time.Second, net.ParseIP("1.2.3.4"))
 
 	var rm metricdata.ResourceMetrics
 	require.NoError(t, reader.Collect(context.Background(), &rm))
 
 	count, sum, found := histogramCountSum(rm, "proxy.session.goodput")
-	require.True(t, found, "goodput histogram should be emitted for a >=1MB session")
+	require.True(t, found, "goodput histogram should be emitted for a session that moved data")
 	assert.Equal(t, uint64(1), count, "exactly one goodput sample")
 	// 1s open duration → goodput ~= received bytes per second.
 	assert.InDelta(t, float64(recv), sum, float64(recv)*0.01)
@@ -63,18 +70,39 @@ func TestSessionGoodput(t *testing.T) {
 	assert.True(t, hasCountry, "goodput sample should carry the geo.country.iso_code attribute")
 }
 
-// TestSessionGoodputBelowThreshold verifies a sub-threshold session records no
-// goodput sample.
-func TestSessionGoodputBelowThreshold(t *testing.T) {
+// TestSessionGoodputSmallSession verifies that a small-but-real session (well
+// under the old 1 MB floor) now records a goodput sample. This is the core of
+// the emission fix: such sessions dominate real traffic in censored markets, and
+// the old floor erased them, false-starving healthy challengers.
+func TestSessionGoodputSmallSession(t *testing.T) {
 	ins, reader := newGoodputInstrument(t)
 
-	ins.SessionGoodput(context.Background(), 42, time.Second, net.ParseIP("1.2.3.4"))
+	// 20 KB received over 2s — comfortably below the old 1 MB floor.
+	const recv = 20 * 1024
+	ins.SessionGoodput(context.Background(), recv, 2*time.Second, net.ParseIP("1.2.3.4"))
+
+	var rm metricdata.ResourceMetrics
+	require.NoError(t, reader.Collect(context.Background(), &rm))
+
+	count, sum, found := histogramCountSum(rm, "proxy.session.goodput")
+	require.True(t, found, "goodput histogram should now be emitted for a small session")
+	assert.Equal(t, uint64(1), count, "exactly one goodput sample")
+	// 20 KB over 2s → ~10 KB/s.
+	assert.InDelta(t, float64(recv)/2.0, sum, float64(recv)*0.01)
+}
+
+// TestSessionGoodputZeroBytes verifies a session that moved no received bytes
+// records nothing (guards against dividing meaningfully on empty connections).
+func TestSessionGoodputZeroBytes(t *testing.T) {
+	ins, reader := newGoodputInstrument(t)
+
+	ins.SessionGoodput(context.Background(), 0, time.Second, net.ParseIP("1.2.3.4"))
 
 	var rm metricdata.ResourceMetrics
 	require.NoError(t, reader.Collect(context.Background(), &rm))
 
 	_, _, found := histogramCountSum(rm, "proxy.session.goodput")
-	assert.False(t, found, "no goodput sample below the byte threshold")
+	assert.False(t, found, "no goodput sample when no bytes were received")
 }
 
 // TestSessionGoodputZeroDuration verifies a non-positive duration records no

--- a/instrument/instrument.go
+++ b/instrument/instrument.go
@@ -26,12 +26,6 @@ var (
 	originRootRegex = regexp.MustCompile(`([^\.]+\.[^\.]+$)`)
 )
 
-// goodputMinBytes is the minimum received bytes a session must have moved
-// before its goodput sample is recorded. Filters out idle/tiny connections
-// whose bytes/duration is dominated by setup and idle time rather than actual
-// transfer speed.
-const goodputMinBytes = 1_000_000
-
 // Instrument is the common interface about what can be instrumented.
 type Instrument interface {
 	WrapFilter(prefix string, f filters.Filter) (filters.Filter, error)
@@ -316,22 +310,35 @@ func (ins *defaultInstrument) ProxiedBytes(ctx context.Context, sent, recv int, 
 	ins.statsMx.Unlock()
 }
 
-// SessionGoodput records a session's download goodput (received bytes per
-// second of connection lifetime) at close, for sessions that moved at least
-// goodputMinBytes. duration is the connection's open time; it includes idle
-// periods, so this is a floor on true transfer speed — but both arms of a
-// bandit experiment are measured identically, so it's a fair relative signal,
-// and the byte floor filters the worst idle-dominated noise. No device_id tag
-// (cardinality). track is emitted as a point attribute keyed "track": the bandit
-// evaluator slices goodput per (track, country) and queries that low-cardinality
-// point attribute (matching lantern-box). The resource also carries the track as
-// semconv.ProxyTrackKey ("proxy.track"), but the metrics pipeline doesn't expose
-// resource attributes as queryable labels, so the evaluator's "track" filter
-// can't see it — hence the explicit point attribute. cloud.region is left to the
-// resource: the strata are (track, country) only and a challenger is pinned to
-// one DC, so region would add cardinality without decision value.
+// SessionGoodput records a session's goodput (received bytes per second of
+// connection lifetime) at close, for any session that moved data over a
+// positive lifetime.
+//
+// It records the "receive" direction — bytes the proxy read from the client
+// (client→proxy), which is the smaller, upload side of a typical browsing
+// session. Both arms of a bandit experiment are measured identically, so this
+// is a fair relative signal; the reader (lantern-cloud GoodputByStratum) is
+// pinned to network.io.direction="receive", so this direction must be preserved
+// here.
+//
+// There is deliberately NO minimum-byte floor. A prior 1 MB floor erased the
+// signal for small-but-real sessions: prod averages ~22 KB received and ~275 KB
+// sent per session (both far under 1 MB), so challengers serving thousands of
+// small sessions (probes, connectivity checks, blocked-then-retry, small pages
+// — common in censored markets) emitted near-zero goodput and were false-retired
+// as "starved." Emitting for every session with recvBytes > 0 makes the sample
+// count track real traffic. Very short/tiny sessions produce noisy per-second
+// rates, but the evaluator compares per-(track, country) p50 medians, which are
+// robust to that tail, so we keep the sample rather than drop, cap, or weight it.
+//
+// No device_id tag (cardinality). track is emitted as a point attribute keyed
+// "track": the bandit evaluator slices goodput per (track, country) and queries
+// that low-cardinality point attribute (matching lantern-box). The resource also
+// carries the track as semconv.ProxyTrackKey ("proxy.track"). cloud.region is
+// left to the resource: the strata are (track, country) only and a challenger is
+// pinned to one DC, so region would add cardinality without decision value.
 func (ins *defaultInstrument) SessionGoodput(ctx context.Context, recvBytes int, duration time.Duration, clientIP net.IP) {
-	if recvBytes < goodputMinBytes || duration <= 0 {
+	if recvBytes <= 0 || duration <= 0 {
 		return
 	}
 	goodput := float64(recvBytes) / duration.Seconds()

--- a/instrument/otelinstrument/otelinstrument.go
+++ b/instrument/otelinstrument/otelinstrument.go
@@ -47,6 +47,18 @@ func Initialize() error {
 	return err
 }
 
+// ResetForTest re-runs initialization against the current global meter provider.
+// initialize() is guarded by a sync.Once, so once the process has initialized
+// the instruments they stay bound to whichever meter provider was global at the
+// time — a meter provider swapped in later (e.g. a test's in-memory reader) is
+// ignored. Tests call this after installing their own provider so the package's
+// instruments record into that provider's reader. It must not be used outside
+// tests.
+func ResetForTest() error {
+	initOnce = sync.Once{}
+	return Initialize()
+}
+
 func initialize() error {
 	meter = otel.GetMeterProvider().Meter("")
 	var err error

--- a/instrument/otelinstrument/otelinstrument.go
+++ b/instrument/otelinstrument/otelinstrument.go
@@ -7,6 +7,8 @@ package otelinstrument
 
 import (
 	"context"
+	"errors"
+	"flag"
 	"net/http"
 	"sync"
 	"time"
@@ -57,8 +59,13 @@ func Initialize() error {
 //
 // It mutates package-global initialization state (initOnce, meter, and the
 // instrument handles) without synchronization, so it is only safe for
-// sequential tests; do not call it from tests that run with t.Parallel().
+// sequential tests; do not call it from tests that run with t.Parallel(). It
+// refuses to run outside a `go test` binary (detected via the test.v flag) so
+// a stray production call can't re-run initialization and race live metric use.
 func ResetForTest() error {
+	if flag.Lookup("test.v") == nil {
+		return errors.New("otelinstrument: ResetForTest may only be called from a test binary")
+	}
 	initOnce = sync.Once{}
 	return Initialize()
 }
@@ -96,16 +103,18 @@ func initialize() error {
 	if Connections, err = meter.Int64Counter("proxy.connections"); err != nil {
 		return err
 	}
-	// Per-session download goodput (received bytes per second of connection
-	// lifetime), recorded once at connection close for sessions that moved at
-	// least goodputMinBytes. Sliceable by track × geo.country.iso_code (both
-	// point attrs) so the bandit experiment evaluator can compare a challenger
-	// track's median goodput against the incumbent's per market; cloud.region
-	// stays a resource attr. Unit "bytes/s" follows proxy.io's "bytes"
-	// spelling for consistency within this package's metrics.
+	// Per-session goodput (received bytes per second of connection lifetime),
+	// recorded once at connection close for any session that moved received
+	// bytes over a positive lifetime (see instrument.SessionGoodput for why
+	// there is no byte floor). "received" is the client→proxy direction, tagged
+	// network.io.direction="receive". Sliceable by track × geo.country.iso_code
+	// (both point attrs) so the bandit experiment evaluator can compare a
+	// challenger track's median goodput against the incumbent's per market;
+	// cloud.region stays a resource attr. Unit "bytes/s" follows proxy.io's
+	// "bytes" spelling for consistency within this package's metrics.
 	if SessionGoodput, err = meter.Float64Histogram("proxy.session.goodput",
 		metric.WithUnit("bytes/s"),
-		metric.WithDescription("Per-session download goodput: received bytes per second of connection lifetime")); err != nil {
+		metric.WithDescription("Per-session goodput: received (client->proxy) bytes per second of connection lifetime")); err != nil {
 		return err
 	}
 

--- a/instrument/otelinstrument/otelinstrument.go
+++ b/instrument/otelinstrument/otelinstrument.go
@@ -54,6 +54,10 @@ func Initialize() error {
 // ignored. Tests call this after installing their own provider so the package's
 // instruments record into that provider's reader. It must not be used outside
 // tests.
+//
+// It mutates package-global initialization state (initOnce, meter, and the
+// instrument handles) without synchronization, so it is only safe for
+// sequential tests; do not call it from tests that run with t.Parallel().
 func ResetForTest() error {
 	initOnce = sync.Once{}
 	return Initialize()


### PR DESCRIPTION
## What & why

`proxy.session.goodput` is recorded once per session at connection close, but only for sessions that moved **≥ 1 MB** in the `receive` direction:

```go
const goodputMinBytes = 1_000_000
func (ins *defaultInstrument) SessionGoodput(ctx, recvBytes int, duration, clientIP) {
    if recvBytes < goodputMinBytes || duration <= 0 { return }  // < 1 MB → no sample
    ...
}
```

The bandit experiment evaluator (lantern-cloud) reads the **count** of goodput samples per `(track, country)` as a starvation signal: a challenger with `< 10` samples in 48h is retired ("starved / infra-broken", 0 samples → aborted). On prod ~79% of challengers were being false-retired this way while serving large real traffic.

**Root cause (confirmed): the 1 MB per-session floor is applied to the `receive` direction, which is the *small* (client→proxy / upload) side of a session, and the floor is ~1–2 orders of magnitude larger than a typical session moves.** Small-but-real sessions — probes, connectivity checks, blocked-then-retry, small pages, which dominate censored markets — record a `bandit.callback` but no goodput sample, so the evaluator counts ≈0 goodput and kills healthy challengers.

This PR removes the byte floor: goodput is now emitted for **any session with `recvBytes > 0` and `duration > 0`**, so the sample count tracks real traffic. Direction, `(track, country)` point-attribute slicing (#675), and the histogram definition are unchanged.

## Prod evidence (SigNoz, 48h)

Two proxy services emit goodput: `http-proxy-lantern` (the cloud http-proxy fleet, **no `deployment.environment` tag**) and `vps-proxy` (`env=prod`; runs both http-proxy and the sing-box/lantern-box binary). `bandit.callbacks` is emitted by the `api` service. Figures below are across both proxy services (no env filter) — a `deployment.environment='prod'` filter silently drops the larger `http-proxy-lantern` fleet.

> Note: the evaluator's goodput query (`GoodputByStratum`) filters only `track IN [...] AND network.io.direction='receive'` — **no env/service filter** — so the missing env tag does *not* blind the evaluator; it only affects human prod-scoped dashboards/alerts. The floor is the single active cause here.

**`proxy.io` bytes by direction** (both services combined):
- `transmit` (proxy→client, download) = **51.9 TB**
- `receive`  (client→proxy, upload)   = **4.81 TB**  → transmit:receive ≈ **10.8 : 1** (`http-proxy-lantern` alone 12.4:1)

**Average bytes per connection** (`http-proxy-lantern`, the only service with `proxy.connections`; **146.5 M** sessions/48h):
- receive (upload, the direction goodput floors on): **≈ 22.2 KB/session**
- transmit (download): **≈ 274 KB/session**

Both averages are **far below the 1 MB floor**; the floored direction (upload) is ~45× under it, and even download is ~3.6× under. Only **0.042%** of connections (61,903 / 146.5 M) ever cleared the floor. Overall goodput samples (166,208) are **0.43%** of `bandit.callbacks` (38.6 M).

**Callbacks vs goodput samples, the false-starved challengers** (all on `service.name=http-proxy-lantern`, i.e. the http-proxy binary this PR fixes):

| track | protocol | `bandit.callbacks` | `proxy.session.goodput.count` | goodput / callbacks |
|---|---|--:|--:|--:|
| exp-7-cn-l5-p21  | tls_1.0.0         | 451,666 | 375  | 0.083% |
| exp-30-ir-l5-p26 | starbridge_1.0.0  | 196,282 | 4,633 | 2.36% |
| exp-50-cn-l5-p24 | tlsmasq_1.1.0     | 6,636   | 2    | 0.030% |
| exp-29-ir-l5-p25 | shadowsocks_1.0.0 | 1,809   | 0    | 0% |
| exp-28-ir-l5-p24 | tlsmasq_1.1.0     | 907     | 0    | 0% |

(Matches the original prod diagnosis table.)

## Audit answers

**Q1 — Is the 1 MB floor the dominant cause? Every close path checked.**
- Single call site: `reporting.go` `proxiedBytesReporter`, on `final=true` (connection close), before the zero-delta early return, with cumulative `stats.RecvTotal` / `stats.Duration`. It fires once for **every** closed measured connection.
- The measured wrapper (`bwReporting.wrapper`) is added via `srv.AddListenerWrappers` and applied by `server.serve()` to every accepted connection, for **every** protocol listener in `getProtoListenersArgs` (https/tls, https_multiplex, tlsmasq, starbridge, broflake, algeneva, kcp, quic_ietf, shadowsocks, shadowsocks_multiplex, water, vmess) and in both the multipath and non-multipath serve paths. For multiplexed transports the measured wrapper is outermost and wraps the per-session logical stream, so `Duration` is per-session and `final` fires per session.
- CONNECT tunnels and early/panic closes all close the measured conn → `final` fires.
- So within http-proxy the 1 MB floor is the **only** filter dropping samples. Confirmed by the prod averages above.
- **One gap noted:** `ListenAndServeENHTTP` (encapsulated-HTTP mode) is a mutually-exclusive alternate serve path that uses a plain `http.Server` and does **not** apply the measured wrapper, so it emits neither `proxy.io` nor goodput. Niche deployment; flagged, not addressed here.

**Q2 — Image / protocol coverage (which binaries emit goodput):**

Serving binary is decided by a track's `docker_image_ref`, not the wire protocol name (shadowsocks/vmess/algeneva/water have listeners on both binaries). In lantern-cloud (`origin/main`): `cmd/api/pcfg/pcfg.go` `generateLaunchConfig` (pcfg.go:136) builds a typed launch config; `cmd/api/proxyini/proxyini.go` `Build` (proxyini.go:73) renders it as an http-proxy INI, or rejects a sing-box config (proxyini.go:208-212) → runs on lantern-box. Sing-box membership: `IsSingboxProtocol` (pcfg/singbox.go:28-37). Per-track image classification: `track.go:180-201`; SQL split rule `proxy_infrastructure.sql:1692-1712`.

- **http-proxy binary** (`service.name` `http-proxy-lantern` + part of `vps-proxy`): **tls, tlsmasq, shadowsocks (protocol 1), vmess, starbridge, algeneva, water, broflake**. Emits goodput, `track` visible as a point attr (#675), 1 MB floor. **Fixed by this PR.**
- **lantern-box / sing-box binary** (`service.name=vps-proxy`): **reflex, samizdat, meek, unbounded, wireguard, hysteria2, vless, trojan, amnezia, sing-box-native ss/vmess**. Also emits `proxy.session.goodput` (`tracker/metrics/metrics.go:66-71`; recorded at `tracker/metrics/tracker.go:142-155`) with the **identical `goodputMinBytes = 1_000_000`** (`tracker.go:28,143`). In prod its tracks under-emit the same way (e.g. samizdat-pro-alicloud, hysteria2-\*, vless-\*). **Needs the same floor fix — separate PR in lantern-box.**
- **radiance**: **not a provisioned proxy image** (`git grep radiance` over lantern-cloud `cmd/api`, `cmd/phost`, `tf/` = 0 hits) and emits **zero** `proxy.session.goodput` — its only "goodput" is a local KB/s CLI probe in `cmd/residential-urltest` (main.go:237,262); serving telemetry records `connectionDuration` only. Not part of the experiment fleet.
- **Old `getlantern/http-proxy-lantern` repo**: **not deployed** — absent from the CI/deploy allowlist `[automation, flashlight, http-proxy, lantern-cloud, lantern-box]` (`tf/_modules/foundation/lanternet/cicd.tf:35-41`); the deployed image is `http-proxy:latest` (`cmd/phost/main.go:50`). It is a byte-identical mirror of this repo (same HEAD SHA), so no divergent goodput path.
- **No total (non-emitting-binary) gap** among live serving binaries — both http-proxy and lantern-box emit. (I initially suspected lantern-box tagged `track` resource-only / reader-invisible; **prod refutes this** — `track` resolves as a queryable label on `vps-proxy` goodput, and `GoodputByStratum` has no service filter, so it matches both. The floor is the sole active cause.)

The 5 false-starved tracks are all http-proxy (Class A) — proven empirically: three show non-zero goodput (375 / 4,633 / 2), which a resource-only-track binary could never do (the reader's point-attr `track` filter would read exactly 0 in every stratum). The two 0-rows are the floor on low-volume http-proxy tracks, same mechanism as the tlsmasq row that yielded 2 from 6,636 callbacks.

**Q3 — Are `recvBytes` / `duration` populated for all protocols?**
- Yes, uniformly: the measured listener sits above all protocol listeners at the server level and is protocol-agnostic (`measured.Conn` wrapping the client socket), so there's no per-protocol silent-zero within http-proxy.
- Semantic note: `recvBytes = stats.RecvTotal` is the **client→proxy (upload)** direction (tagged `receive`), the *smaller* side — even though the code/histogram describe it as "download goodput". This is internally consistent across both emitters and the reader (all pinned to `receive`), so it's a fair *relative* signal and I preserved it. But it does mean the metric measures upload throughput, not download; if the team wants download as the quality signal that's a coordinated emitter+reader change (see follow-ups).

## Changes

- `instrument/instrument.go`: remove `goodputMinBytes`; emit goodput for any session with `recvBytes > 0 && duration > 0`; rewrite the doc comment with the rationale + prod numbers.
- `instrument/goodput_test.go`: add `TestSessionGoodputSmallSession` (20 KB session now records — the core fix) and `TestSessionGoodputZeroBytes`; keep the ≥1 MB and zero-duration cases.
- `instrument/otelinstrument/otelinstrument.go`: add `ResetForTest()` — fixes a latent, order-dependent test-harness leak (the `sync.Once` in `Initialize()` bound the goodput histogram to the *first* test's meter provider, so only the first positive-emission test in the process ever observed samples).

## Test evidence

```
$ go test ./instrument/...
ok  github.com/getlantern/http-proxy-lantern/v2/instrument
--- PASS: TestSessionGoodput
--- PASS: TestSessionGoodputSmallSession
--- PASS: TestSessionGoodputZeroBytes
--- PASS: TestSessionGoodputZeroDuration
```
All four pass in any order (verified standalone). `go vet ./instrument/... ./instrument/otelinstrument/...` clean. `go build ./...` fails only inside the unrelated CGO dep `github.com/anacrolix/go-libutp` (`typedef uint8 bool`, a C-toolchain issue) on both this branch and origin/main; the changed packages build clean.

## Volume / cardinality

Removing the floor raises the number of histogram **records** (~846/s fleet-wide, same as `proxy.connections`) but not series cardinality — the label set `(track, geo.country.iso_code, network.io.direction)` is unchanged and low-cardinality. Distinct from the measurement-table volume concern in getlantern/engineering#3691.

## Cross-repo follow-ups (NOT in this PR — coordinate)

1. **lantern-box** (`tracker/metrics/tracker.go:28,143`): apply the identical floor removal — same `goodputMinBytes = 1_000_000`, and it serves the sing-box experiment protocols (reflex, samizdat, hysteria2, vless, trojan, amnezia, wireguard, meek, sing-box-native ss/vmess), all under-emitting. (Also worth confirming lantern-box carries a `track` **point** attribute — its code sets `track` on the OTEL resource, though in prod SigNoz exposes it as a queryable label today.)
2. **lantern-cloud** starvation check (`cmd/api/jobs/experiment_evaluator_worker.go`, `settingExperimentStarvationMinSamples`): gate starvation on `bandit.callbacks`/attempts rather than goodput sample count — a challenger with thousands of callbacks is not starved regardless of goodput emission. (A worktree for this already exists.)
3. **Direction/naming**: decide whether goodput should measure download (transmit) instead of upload (receive). If so it's a coordinated change across both emitters and the reader's `network.io.direction='receive'` filter.

⚠️ Goodput drives real promote/retire decisions on prod — coordinating before merge.
