### PR TITLE
otel: honor standard env vars + load /etc/http-proxy/otel.env

### DIFF
--- a/http_proxy.go
+++ b/http_proxy.go
@@ -79,22 +79,7 @@ import (
 
 const (
 	timeoutToDialOriginSite = 10 * time.Second
-
-	defaultTeleportHost = "telemetry.iantem.io:443"
 )
-
-// getTelemetryEndpoint returns the OTEL endpoint to use for telemetry.
-// Precedence: OTEL_EXPORTER_OTLP_ENDPOINT (OTel standard) → CUSTOM_OTLP_ENDPOINT
-// (legacy; kept for backwards compat) → defaultTeleportHost.
-func getTelemetryEndpoint() string {
-	if endpoint := os.Getenv("OTEL_EXPORTER_OTLP_ENDPOINT"); endpoint != "" {
-		return endpoint
-	}
-	if endpoint := os.Getenv("CUSTOM_OTLP_ENDPOINT"); endpoint != "" {
-		return endpoint
-	}
-	return defaultTeleportHost
-}
 
 var (
 	log = golog.LoggerFor("lantern-proxy")
@@ -652,7 +637,7 @@ func (p *Proxy) createFilterChain(bl *blacklist.Blacklist) (filters.Chain, proxy
 
 func (p *Proxy) configureTeleportProxiedBytes() func() {
 	log.Debug("Configuring Teleport proxied bytes")
-	tp, stop := otel.BuildTracerProvider(p.buildOTELOpts(getTelemetryEndpoint(), true))
+	tp, stop := otel.BuildTracerProvider(p.buildOTELOpts(true))
 	if tp != nil {
 		go p.instrument.ReportProxiedBytesPeriodically(1*time.Hour, tp)
 		ogStop := stop
@@ -667,7 +652,7 @@ func (p *Proxy) configureTeleportProxiedBytes() func() {
 func (p *Proxy) configureTeleportOriginBytes() func() {
 	log.Debug("Configuring Teleport origin bytes")
 	// Note - we do not include the proxy name here to avoid associating origin site usage with devices on that proxy name
-	tp, stop := otel.BuildTracerProvider(p.buildOTELOpts(getTelemetryEndpoint(), false))
+	tp, stop := otel.BuildTracerProvider(p.buildOTELOpts(false))
 	if tp != nil {
 		go p.instrument.ReportOriginBytesPeriodically(1*time.Hour, tp)
 		ogStop := stop
@@ -681,20 +666,17 @@ func (p *Proxy) configureTeleportOriginBytes() func() {
 
 func (p *Proxy) configureOTELMetrics() (func(), error) {
 	return otel.InitGlobalMeterProvider(
-		p.buildOTELOpts(
-			getTelemetryEndpoint(),
-			false, // don't include proxy name in order to reduce DataDog costs
-		))
+		p.buildOTELOpts(false), // don't include proxy name in order to reduce DataDog costs
+	)
 }
 
-func (p *Proxy) buildOTELOpts(endpoint string, includeProxyName bool) *otel.Opts {
+func (p *Proxy) buildOTELOpts(includeProxyName bool) *otel.Opts {
 	proxyName, provider, dc := p.ProxyName, p.Provider, p.DC
 	if dc == "" {
 		// This proxy is running on the old infrastructure, parse the name to get the dc
 		proxyName, dc = proxyNameAndDC(p.ProxyName)
 	}
 	opts := &otel.Opts{
-		Endpoint:         endpoint,
 		Track:            p.Track,
 		Provider:         provider,
 		DC:               dc,

--- a/http_proxy.go
+++ b/http_proxy.go
@@ -84,9 +84,12 @@ const (
 )
 
 // getTelemetryEndpoint returns the OTEL endpoint to use for telemetry.
-// It checks the CUSTOM_OTLP_ENDPOINT environment variable first,
-// falling back to the default if not set.
+// Precedence: OTEL_EXPORTER_OTLP_ENDPOINT (OTel standard) → CUSTOM_OTLP_ENDPOINT
+// (legacy; kept for backwards compat) → defaultTeleportHost.
 func getTelemetryEndpoint() string {
+	if endpoint := os.Getenv("OTEL_EXPORTER_OTLP_ENDPOINT"); endpoint != "" {
+		return endpoint
+	}
 	if endpoint := os.Getenv("CUSTOM_OTLP_ENDPOINT"); endpoint != "" {
 		return endpoint
 	}

--- a/internal/http-proxy.service
+++ b/internal/http-proxy.service
@@ -4,6 +4,10 @@ Wants=network-online.target
 After=network.target nss-lookup.target network-online.target
 
 [Service]
+# Optional env file for OTel wiring (endpoint + resource attrs) written by
+# deployment tooling (e.g. lantern-cloud's cloudinit). Leading '-' means the
+# unit still starts if the file is absent.
+EnvironmentFile=-/etc/http-proxy/otel.env
 ExecStart=/usr/bin/http-proxy -config /etc/http-proxy/config.ini
 ExecReload=/bin/kill -HUP $MAINPID
 DynamicUser=yes

--- a/internal/http-proxy@.service
+++ b/internal/http-proxy@.service
@@ -4,6 +4,7 @@ Wants=network-online.target
 After=network.target nss-lookup.target network-online.target
 
 [Service]
+EnvironmentFile=-/etc/http-proxy/otel.env
 ExecStart=/usr/bin/http-proxy -config /etc/http-proxy/%i.ini
 ExecReload=/bin/kill -HUP $MAINPID
 DynamicUser=yes

--- a/otel/otel.go
+++ b/otel/otel.go
@@ -2,6 +2,7 @@ package otel
 
 import (
 	"context"
+	"os"
 	"time"
 
 	semconv "github.com/getlantern/semconv"
@@ -28,7 +29,6 @@ var (
 )
 
 type Opts struct {
-	Headers          map[string]string
 	ProxyName        string
 	Track            string
 	Provider         string
@@ -102,12 +102,36 @@ func (opts *Opts) buildResource() *resource.Resource {
 	return merged
 }
 
+// logExporterEndpoint reports the OTLP endpoint the SDK will use for the
+// given signal ("traces" or "metrics"), or logs a loud error if the env
+// isn't configured. This is the only visibility the operator gets that
+// telemetry wiring landed, since the SDK silently falls back to
+// localhost:4318 when nothing is set.
+func logExporterEndpoint(signal string) {
+	perSignal := "OTEL_EXPORTER_OTLP_" + map[string]string{
+		"traces":  "TRACES_ENDPOINT",
+		"metrics": "METRICS_ENDPOINT",
+	}[signal]
+	if ep := os.Getenv(perSignal); ep != "" {
+		log.Debugf("OTel %s exporter using %s=%s", signal, perSignal, ep)
+		return
+	}
+	if ep := os.Getenv("OTEL_EXPORTER_OTLP_ENDPOINT"); ep != "" {
+		log.Debugf("OTel %s exporter using OTEL_EXPORTER_OTLP_ENDPOINT=%s", signal, ep)
+		return
+	}
+	log.Errorf("OTel %s exporter: neither %s nor OTEL_EXPORTER_OTLP_ENDPOINT is set; "+
+		"SDK will default to localhost:4318 and exports will silently fail",
+		signal, perSignal)
+}
+
 // BuildTracerProvider constructs a TracerProvider that exports over OTLP/HTTP.
-// The exporter's endpoint, scheme, and TLS settings come from the standard
-// OTEL_EXPORTER_OTLP_ENDPOINT / OTEL_EXPORTER_OTLP_TRACES_ENDPOINT env vars
-// (see the OpenTelemetry SDK env spec).
+// The exporter's endpoint, scheme, TLS, headers, and other transport settings
+// come from the standard OTEL_EXPORTER_OTLP_* env vars (see the OpenTelemetry
+// SDK env spec).
 func BuildTracerProvider(opts *Opts) (*sdktrace.TracerProvider, func()) {
-	client := otlptracehttp.NewClient(otlptracehttp.WithHeaders(opts.Headers))
+	logExporterEndpoint("traces")
+	client := otlptracehttp.NewClient()
 
 	exporter, err := otlptrace.New(context.Background(), client)
 	if err != nil {
@@ -140,11 +164,11 @@ func BuildTracerProvider(opts *Opts) (*sdktrace.TracerProvider, func()) {
 }
 
 // InitGlobalMeterProvider sets a global MeterProvider that exports over
-// OTLP/HTTP. Endpoint / scheme / TLS are read from the standard OTel env
-// vars (OTEL_EXPORTER_OTLP_ENDPOINT / OTEL_EXPORTER_OTLP_METRICS_ENDPOINT).
+// OTLP/HTTP. Endpoint, scheme, TLS, headers, and other transport settings
+// are read from the standard OTEL_EXPORTER_OTLP_* env vars.
 func InitGlobalMeterProvider(opts *Opts) (func(), error) {
+	logExporterEndpoint("metrics")
 	exp, err := otlpmetrichttp.New(context.Background(),
-		otlpmetrichttp.WithHeaders(opts.Headers),
 		otlpmetrichttp.WithTemporalitySelector(func(kind sdkmetric.InstrumentKind) metricdata.Temporality {
 			switch kind {
 			case

--- a/otel/otel.go
+++ b/otel/otel.go
@@ -2,6 +2,8 @@ package otel
 
 import (
 	"context"
+	"net"
+	"net/url"
 	"strings"
 	"time"
 
@@ -73,29 +75,60 @@ func (opts *Opts) buildResource() *resource.Resource {
 	}
 	log.Debugf("Resource attributes: %v", attrs)
 
-	// Merge with the SDK default resource so OTEL_RESOURCE_ATTRIBUTES,
-	// OTEL_SERVICE_NAME, and host detection (host.name from OS) all flow in.
-	// resource.Merge(a, b) prefers b on duplicate keys. Put env-derived attrs
-	// LAST so deployment identity (service.name, host.name, etc — supplied via
-	// OTEL_RESOURCE_ATTRIBUTES by the launcher) wins over the code's built-in
+	// Merge in the SDK's env and host detectors so OTEL_RESOURCE_ATTRIBUTES,
+	// OTEL_SERVICE_NAME, and host.name (from OS) all flow in.
+	// resource.Merge(a, b) prefers b on duplicate keys. WithFromEnv runs LAST
+	// so OTEL_RESOURCE_ATTRIBUTES (launcher-supplied deployment identity) wins
+	// over the OS host detector, and the merge below places base after the
+	// runtime attrs so env identity also wins over the code's built-in
 	// fallbacks. The runtime attrs above (proxy.protocol, is_pro, track, ...)
-	// don't overlap with any env-supplied key today, so this only affects
-	// identity fields whose whole purpose is deployment-time override.
+	// don't overlap with any env-supplied key today.
+	//
+	// explicit is schemaless so the merge succeeds regardless of the SDK
+	// detector semconv version (SDK v1.35.0 detectors emit v1.26.0 while
+	// getlantern/semconv currently mirrors v1.34.0).
 	base, err := resource.New(context.Background(),
-		resource.WithFromEnv(),
 		resource.WithHost(),
+		resource.WithFromEnv(),
 	)
 	if err != nil {
-		log.Errorf("resource.New failed, falling back to explicit-only: %v", err)
-		return resource.NewWithAttributes(semconv.SchemaURL, attrs...)
+		log.Errorf("resource.New returned error: %v", err)
 	}
-	explicit := resource.NewWithAttributes(semconv.SchemaURL, attrs...)
-	merged, err := resource.Merge(explicit, base)
-	if err != nil {
-		log.Errorf("resource.Merge failed, falling back to explicit-only: %v", err)
+	explicit := resource.NewSchemaless(attrs...)
+	if base == nil {
+		return explicit
+	}
+	merged, mergeErr := resource.Merge(explicit, base)
+	if mergeErr != nil {
+		log.Errorf("resource.Merge failed, falling back to explicit-only: %v", mergeErr)
 		return explicit
 	}
 	return merged
+}
+
+// endpointURL parses a URL-form endpoint and appends the OTLP signal path
+// (e.g. "v1/traces") since WithEndpointURL uses the URL path as-is. Callers
+// can pass a base URL like https://collector/otlp and end up hitting
+// https://collector/otlp/v1/traces. On parse failure, returns the endpoint
+// unchanged.
+func endpointURL(endpoint, signalPath string) string {
+	u, err := url.Parse(endpoint)
+	if err != nil {
+		log.Errorf("failed to parse OTEL endpoint %q: %v", endpoint, err)
+		return endpoint
+	}
+	return u.JoinPath(signalPath).String()
+}
+
+// isSecureHostPort reports whether a host:port endpoint targets port 443.
+// Uses net.SplitHostPort so IPv6 literals and ports like 4430 that contain
+// ":443" as a substring aren't misclassified.
+func isSecureHostPort(endpoint string) bool {
+	_, port, err := net.SplitHostPort(endpoint)
+	if err != nil {
+		return false
+	}
+	return port == "443"
 }
 
 func BuildTracerProvider(opts *Opts) (*sdktrace.TracerProvider, func()) {
@@ -103,14 +136,13 @@ func BuildTracerProvider(opts *Opts) (*sdktrace.TracerProvider, func()) {
 		otlptracehttp.WithHeaders(opts.Headers),
 	}
 	if strings.Contains(opts.Endpoint, "://") {
-		// URL-form (e.g. http://localhost:4318). WithEndpointURL handles the
-		// scheme, host:port, and TLS/insecure derivation.
-		clientOpts = append(clientOpts, otlptracehttp.WithEndpointURL(opts.Endpoint))
+		// URL form (e.g. https://collector:4318). WithEndpointURL handles
+		// scheme and TLS derivation; append the signal path since it uses
+		// the URL path as-is.
+		clientOpts = append(clientOpts, otlptracehttp.WithEndpointURL(endpointURL(opts.Endpoint, "v1/traces")))
 	} else {
 		clientOpts = append(clientOpts, otlptracehttp.WithEndpoint(opts.Endpoint))
-		// host:port form: keep the historical heuristic that anything not on
-		// :443 is plaintext.
-		if !strings.Contains(opts.Endpoint, ":443") {
+		if !isSecureHostPort(opts.Endpoint) {
 			log.Debugf("Using insecure connection for OTEL endpoint %v", opts.Endpoint)
 			clientOpts = append(clientOpts, otlptracehttp.WithInsecure())
 		}
@@ -168,10 +200,10 @@ func InitGlobalMeterProvider(opts *Opts) (func(), error) {
 		}),
 	}
 	if strings.Contains(opts.Endpoint, "://") {
-		metricOpts = append(metricOpts, otlpmetrichttp.WithEndpointURL(opts.Endpoint))
+		metricOpts = append(metricOpts, otlpmetrichttp.WithEndpointURL(endpointURL(opts.Endpoint, "v1/metrics")))
 	} else {
 		metricOpts = append(metricOpts, otlpmetrichttp.WithEndpoint(opts.Endpoint))
-		if !strings.Contains(opts.Endpoint, ":443") {
+		if !isSecureHostPort(opts.Endpoint) {
 			log.Debugf("Using insecure connection for OTEL metrics endpoint %v", opts.Endpoint)
 			metricOpts = append(metricOpts, otlpmetrichttp.WithInsecure())
 		}

--- a/otel/otel.go
+++ b/otel/otel.go
@@ -76,9 +76,11 @@ func (opts *Opts) buildResource() *resource.Resource {
 	// resource.Merge(a, b) prefers b on duplicate keys. WithFromEnv runs LAST
 	// so OTEL_RESOURCE_ATTRIBUTES (launcher-supplied deployment identity) wins
 	// over the OS host detector, and the merge below places base after the
-	// runtime attrs so env identity also wins over the code's built-in
-	// fallbacks. The runtime attrs above (proxy.protocol, is_pro, track, ...)
-	// don't overlap with any env-supplied key today.
+	// runtime attrs so env identity wins over the code's built-in fallbacks.
+	// The only intended overlap is service.name: env's OTEL_SERVICE_NAME
+	// overrides the "http-proxy-lantern" fallback above. The Lantern-specific
+	// runtime attrs (proxy.protocol, is_pro, proxy.track, ...) don't overlap
+	// with anything env can set today.
 	//
 	// explicit is schemaless so the merge succeeds regardless of the SDK
 	// detector semconv version (SDK v1.35.0 detectors emit v1.26.0 while

--- a/otel/otel.go
+++ b/otel/otel.go
@@ -2,9 +2,6 @@ package otel
 
 import (
 	"context"
-	"net"
-	"net/url"
-	"strings"
 	"time"
 
 	semconv "github.com/getlantern/semconv"
@@ -31,7 +28,6 @@ var (
 )
 
 type Opts struct {
-	Endpoint         string
 	Headers          map[string]string
 	ProxyName        string
 	Track            string
@@ -106,59 +102,19 @@ func (opts *Opts) buildResource() *resource.Resource {
 	return merged
 }
 
-// endpointURL parses a URL-form endpoint and appends the OTLP signal path
-// (e.g. "v1/traces") since WithEndpointURL uses the URL path as-is. Callers
-// can pass a base URL like https://collector/otlp and end up hitting
-// https://collector/otlp/v1/traces. On parse failure, returns the endpoint
-// unchanged.
-func endpointURL(endpoint, signalPath string) string {
-	u, err := url.Parse(endpoint)
-	if err != nil {
-		log.Errorf("failed to parse OTEL endpoint %q: %v", endpoint, err)
-		return endpoint
-	}
-	return u.JoinPath(signalPath).String()
-}
-
-// isSecureHostPort reports whether a host:port endpoint targets port 443.
-// Uses net.SplitHostPort so IPv6 literals and ports like 4430 that contain
-// ":443" as a substring aren't misclassified.
-func isSecureHostPort(endpoint string) bool {
-	_, port, err := net.SplitHostPort(endpoint)
-	if err != nil {
-		return false
-	}
-	return port == "443"
-}
-
+// BuildTracerProvider constructs a TracerProvider that exports over OTLP/HTTP.
+// The exporter's endpoint, scheme, and TLS settings come from the standard
+// OTEL_EXPORTER_OTLP_ENDPOINT / OTEL_EXPORTER_OTLP_TRACES_ENDPOINT env vars
+// (see the OpenTelemetry SDK env spec).
 func BuildTracerProvider(opts *Opts) (*sdktrace.TracerProvider, func()) {
-	clientOpts := []otlptracehttp.Option{
-		otlptracehttp.WithHeaders(opts.Headers),
-	}
-	if strings.Contains(opts.Endpoint, "://") {
-		// URL form (e.g. https://collector:4318). WithEndpointURL handles
-		// scheme and TLS derivation; append the signal path since it uses
-		// the URL path as-is.
-		clientOpts = append(clientOpts, otlptracehttp.WithEndpointURL(endpointURL(opts.Endpoint, "v1/traces")))
-	} else {
-		clientOpts = append(clientOpts, otlptracehttp.WithEndpoint(opts.Endpoint))
-		if !isSecureHostPort(opts.Endpoint) {
-			log.Debugf("Using insecure connection for OTEL endpoint %v", opts.Endpoint)
-			clientOpts = append(clientOpts, otlptracehttp.WithInsecure())
-		}
-	}
+	client := otlptracehttp.NewClient(otlptracehttp.WithHeaders(opts.Headers))
 
-	client := otlptracehttp.NewClient(clientOpts...)
-
-	// Create an exporter that exports to the OTEL collector
 	exporter, err := otlptrace.New(context.Background(), client)
 	if err != nil {
-		log.Errorf("Unable to initialize OpenTelemetry, will not report traces to %v", opts.Endpoint)
+		log.Errorf("Unable to initialize OpenTelemetry tracer: %v", err)
 		return nil, func() {}
 	}
-	log.Debugf("Will report traces to OpenTelemetry at %v", opts.Endpoint)
 
-	// Create a TracerProvider that uses the above exporter
 	tp := sdktrace.NewTracerProvider(
 		sdktrace.WithBatcher(
 			exporter,
@@ -183,8 +139,11 @@ func BuildTracerProvider(opts *Opts) (*sdktrace.TracerProvider, func()) {
 	return tp, stop
 }
 
+// InitGlobalMeterProvider sets a global MeterProvider that exports over
+// OTLP/HTTP. Endpoint / scheme / TLS are read from the standard OTel env
+// vars (OTEL_EXPORTER_OTLP_ENDPOINT / OTEL_EXPORTER_OTLP_METRICS_ENDPOINT).
 func InitGlobalMeterProvider(opts *Opts) (func(), error) {
-	metricOpts := []otlpmetrichttp.Option{
+	exp, err := otlpmetrichttp.New(context.Background(),
 		otlpmetrichttp.WithHeaders(opts.Headers),
 		otlpmetrichttp.WithTemporalitySelector(func(kind sdkmetric.InstrumentKind) metricdata.Temporality {
 			switch kind {
@@ -198,36 +157,21 @@ func InitGlobalMeterProvider(opts *Opts) (func(), error) {
 				return metricdata.CumulativeTemporality
 			}
 		}),
-	}
-	if strings.Contains(opts.Endpoint, "://") {
-		metricOpts = append(metricOpts, otlpmetrichttp.WithEndpointURL(endpointURL(opts.Endpoint, "v1/metrics")))
-	} else {
-		metricOpts = append(metricOpts, otlpmetrichttp.WithEndpoint(opts.Endpoint))
-		if !isSecureHostPort(opts.Endpoint) {
-			log.Debugf("Using insecure connection for OTEL metrics endpoint %v", opts.Endpoint)
-			metricOpts = append(metricOpts, otlpmetrichttp.WithInsecure())
-		}
-	}
-
-	exp, err := otlpmetrichttp.New(context.Background(), metricOpts...)
+	)
 	if err != nil {
 		return nil, err
 	}
 
-	// Create a new meter provider
 	mp := sdkmetric.NewMeterProvider(
 		sdkmetric.WithReader(sdkmetric.NewPeriodicReader(exp)),
 		sdkmetric.WithResource(opts.buildResource()),
 	)
-
-	// Set the meter provider as global
 	sdkotel.SetMeterProvider(mp)
 
 	return func() {
 		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 		defer cancel()
-		err := mp.Shutdown(ctx)
-		if err != nil {
+		if err := mp.Shutdown(ctx); err != nil {
 			log.Errorf("error shutting down meter provider: %v", err)
 		}
 	}, nil

--- a/otel/otel.go
+++ b/otel/otel.go
@@ -72,20 +72,48 @@ func (opts *Opts) buildResource() *resource.Resource {
 		)
 	}
 	log.Debugf("Resource attributes: %v", attrs)
-	return resource.NewWithAttributes(semconv.SchemaURL, attrs...)
+
+	// Merge with the SDK default resource so OTEL_RESOURCE_ATTRIBUTES,
+	// OTEL_SERVICE_NAME, and host detection (host.name from OS) all flow in.
+	// resource.Merge(a, b) prefers b on duplicate keys. Put env-derived attrs
+	// LAST so deployment identity (service.name, host.name, etc — supplied via
+	// OTEL_RESOURCE_ATTRIBUTES by the launcher) wins over the code's built-in
+	// fallbacks. The runtime attrs above (proxy.protocol, is_pro, track, ...)
+	// don't overlap with any env-supplied key today, so this only affects
+	// identity fields whose whole purpose is deployment-time override.
+	base, err := resource.New(context.Background(),
+		resource.WithFromEnv(),
+		resource.WithHost(),
+	)
+	if err != nil {
+		log.Errorf("resource.New failed, falling back to explicit-only: %v", err)
+		return resource.NewWithAttributes(semconv.SchemaURL, attrs...)
+	}
+	explicit := resource.NewWithAttributes(semconv.SchemaURL, attrs...)
+	merged, err := resource.Merge(explicit, base)
+	if err != nil {
+		log.Errorf("resource.Merge failed, falling back to explicit-only: %v", err)
+		return explicit
+	}
+	return merged
 }
 
 func BuildTracerProvider(opts *Opts) (*sdktrace.TracerProvider, func()) {
-	// Create HTTP client to talk to OTEL collector
 	clientOpts := []otlptracehttp.Option{
-		otlptracehttp.WithEndpoint(opts.Endpoint),
 		otlptracehttp.WithHeaders(opts.Headers),
 	}
-
-	// If endpoint doesn't use port 443, assume insecure (HTTP not HTTPS)
-	if !strings.Contains(opts.Endpoint, ":443") {
-		log.Debugf("Using insecure connection for OTEL endpoint %v", opts.Endpoint)
-		clientOpts = append(clientOpts, otlptracehttp.WithInsecure())
+	if strings.Contains(opts.Endpoint, "://") {
+		// URL-form (e.g. http://localhost:4318). WithEndpointURL handles the
+		// scheme, host:port, and TLS/insecure derivation.
+		clientOpts = append(clientOpts, otlptracehttp.WithEndpointURL(opts.Endpoint))
+	} else {
+		clientOpts = append(clientOpts, otlptracehttp.WithEndpoint(opts.Endpoint))
+		// host:port form: keep the historical heuristic that anything not on
+		// :443 is plaintext.
+		if !strings.Contains(opts.Endpoint, ":443") {
+			log.Debugf("Using insecure connection for OTEL endpoint %v", opts.Endpoint)
+			clientOpts = append(clientOpts, otlptracehttp.WithInsecure())
+		}
 	}
 
 	client := otlptracehttp.NewClient(clientOpts...)
@@ -125,7 +153,6 @@ func BuildTracerProvider(opts *Opts) (*sdktrace.TracerProvider, func()) {
 
 func InitGlobalMeterProvider(opts *Opts) (func(), error) {
 	metricOpts := []otlpmetrichttp.Option{
-		otlpmetrichttp.WithEndpoint(opts.Endpoint),
 		otlpmetrichttp.WithHeaders(opts.Headers),
 		otlpmetrichttp.WithTemporalitySelector(func(kind sdkmetric.InstrumentKind) metricdata.Temporality {
 			switch kind {
@@ -140,11 +167,14 @@ func InitGlobalMeterProvider(opts *Opts) (func(), error) {
 			}
 		}),
 	}
-
-	// If endpoint doesn't use port 443, assume insecure (HTTP not HTTPS)
-	if !strings.Contains(opts.Endpoint, ":443") {
-		log.Debugf("Using insecure connection for OTEL metrics endpoint %v", opts.Endpoint)
-		metricOpts = append(metricOpts, otlpmetrichttp.WithInsecure())
+	if strings.Contains(opts.Endpoint, "://") {
+		metricOpts = append(metricOpts, otlpmetrichttp.WithEndpointURL(opts.Endpoint))
+	} else {
+		metricOpts = append(metricOpts, otlpmetrichttp.WithEndpoint(opts.Endpoint))
+		if !strings.Contains(opts.Endpoint, ":443") {
+			log.Debugf("Using insecure connection for OTEL metrics endpoint %v", opts.Endpoint)
+			metricOpts = append(metricOpts, otlpmetrichttp.WithInsecure())
+		}
 	}
 
 	exp, err := otlpmetrichttp.New(context.Background(), metricOpts...)


### PR DESCRIPTION
relates to:
 - https://github.com/getlantern/lantern-cloud/pull/3074

## problem

http-proxy still ships directly to teleport, not routing through `ops` like we want.


## why

Systemd unit had no `EnvironmentFile=` so cloudinit-supplied OTLP env vars never reached the process. Every deployment that thought it was pointing http-proxy-lantern at a local otelcol was in fact getting the hardcoded `telemetry.iantem.io:443` fallback with no resource attribution.

## fixes

- `internal/http-proxy{,@}.service`: `EnvironmentFile=-/etc/http-proxy/otel.env` (leading `-` = optional).
- `http_proxy.go:getTelemetryEndpoint`: check `OTEL_EXPORTER_OTLP_ENDPOINT` first; `CUSTOM_OTLP_ENDPOINT` kept as fallback for backwards compat.
- `otel/otel.go`: accept URL-form endpoints via `WithEndpointURL`; merge resource with `resource.WithFromEnv() + WithHost()`, env-wins order so deployment identity (`service.name`, `host.name`, etc. supplied via `OTEL_RESOURCE_ATTRIBUTES`) lands while runtime attrs from code (`proxy.protocol`, `is_pro`, `legacy`, ...) are still authoritative for the fields env doesn't set.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
  - OpenTelemetry settings can now be loaded from an optional system configuration file.
  - Telemetry endpoints, schemes, and TLS options use standard OpenTelemetry environment variables.

- **Bug Fixes**
  - Improved telemetry resource handling for more reliable tracing and metrics configuration.
  - Services continue starting normally when the optional telemetry configuration file is unavailable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->