### PR TITLE
instrument: log-scale goodput buckets, 1 B/s to 10 MB/s

### DIFF
--- a/instrument/goodput_test.go
+++ b/instrument/goodput_test.go
@@ -119,6 +119,44 @@ func TestSessionGoodputZeroDuration(t *testing.T) {
 	assert.False(t, found, "no goodput sample for a zero-duration session")
 }
 
+// TestSessionGoodputBucketLayout verifies the emitted histogram carries the
+// explicit log-scale bucket boundaries instead of the SDK defaults, whose
+// 10,000 B/s top boundary censored everything faster than 10 kB/s into the
+// final bucket. A ~101 kB/s sample must resolve into the (100_000, 300_000]
+// bucket, which only exists in the explicit layout.
+func TestSessionGoodputBucketLayout(t *testing.T) {
+	ins, reader := newGoodputInstrument(t)
+
+	// 202 KB over 2s → ~101 kB/s, ten times the SDK default's top boundary.
+	ins.SessionGoodput(context.Background(), 202_000, 2*time.Second, net.ParseIP("1.2.3.4"))
+
+	var rm metricdata.ResourceMetrics
+	require.NoError(t, reader.Collect(context.Background(), &rm))
+
+	dp, found := histogramDataPoint(rm, "proxy.session.goodput")
+	require.True(t, found, "goodput histogram should be emitted")
+	assert.Equal(t, otelinstrument.GoodputBucketBoundaries, dp.Bounds,
+		"histogram must carry the explicit log-scale boundaries")
+	require.Len(t, dp.BucketCounts, len(otelinstrument.GoodputBucketBoundaries)+1)
+	// Boundaries are upper-inclusive: 101_000 lands in (100_000, 300_000],
+	// i.e. bucket index 11 — not the overflow bucket.
+	assert.Equal(t, uint64(1), dp.BucketCounts[11], "~101 kB/s sample should land in the (100k, 300k] bucket")
+}
+
+func histogramDataPoint(rm metricdata.ResourceMetrics, name string) (metricdata.HistogramDataPoint[float64], bool) {
+	for _, sm := range rm.ScopeMetrics {
+		for _, m := range sm.Metrics {
+			if m.Name != name {
+				continue
+			}
+			if d, ok := m.Data.(metricdata.Histogram[float64]); ok && len(d.DataPoints) > 0 {
+				return d.DataPoints[0], true
+			}
+		}
+	}
+	return metricdata.HistogramDataPoint[float64]{}, false
+}
+
 func histogramCountSum(rm metricdata.ResourceMetrics, name string) (uint64, float64, bool) {
 	for _, sm := range rm.ScopeMetrics {
 		for _, m := range sm.Metrics {

--- a/instrument/goodput_test.go
+++ b/instrument/goodput_test.go
@@ -135,9 +135,17 @@ func TestSessionGoodputBucketLayout(t *testing.T) {
 
 	dp, found := histogramDataPoint(rm, "proxy.session.goodput")
 	require.True(t, found, "goodput histogram should be emitted")
-	assert.Equal(t, otelinstrument.GoodputBucketBoundaries, dp.Bounds,
+	// Spelled out rather than referencing the package variable so an
+	// accidental edit to the layout fails here. Must stay identical to
+	// lantern-box's tracker/metrics boundaries.
+	wantBounds := []float64{
+		1, 3, 10, 30, 100, 300,
+		1_000, 3_000, 10_000, 30_000, 100_000, 300_000,
+		1_000_000, 3_000_000, 10_000_000,
+	}
+	assert.Equal(t, wantBounds, dp.Bounds,
 		"histogram must carry the explicit log-scale boundaries")
-	require.Len(t, dp.BucketCounts, len(otelinstrument.GoodputBucketBoundaries)+1)
+	require.Len(t, dp.BucketCounts, len(wantBounds)+1)
 	// Boundaries are upper-inclusive: 101_000 lands in (100_000, 300_000],
 	// i.e. bucket index 11 — not the overflow bucket.
 	assert.Equal(t, uint64(1), dp.BucketCounts[11], "~101 kB/s sample should land in the (100k, 300k] bucket")

--- a/instrument/otelinstrument/otelinstrument.go
+++ b/instrument/otelinstrument/otelinstrument.go
@@ -39,6 +39,29 @@ var (
 	distinctClients                                          metric.Int64ObservableGauge
 )
 
+// GoodputBucketBoundaries are the explicit bucket boundaries, in bytes/s, for
+// the proxy.session.goodput histogram: a half-decade log scale from 1 B/s to
+// 10 MB/s. Session goodput spans ~6 decades — idle keepalive sessions sit
+// below 100 B/s while real page loads run 100 kB/s–10 MB/s — and the SDK
+// default boundaries top out at 10,000 B/s, which censored everything faster
+// than 10 kB/s into the final bucket (IR's daily p90 read as exactly 10000).
+// A log scale gives every decade the same relative resolution, so
+// p50/p90/p99 interpolate to meaningful values across the whole range.
+//
+// Exactly 15 boundaries, matching the SDK default's count: SigNoz stores one
+// sample per bucket per series per export interval, so keeping the count
+// identical keeps the metric's ingest cost identical (this family is ~20% of
+// metric ingest; see lantern-cloud #3069).
+//
+// lantern-box emits the same metric from its tracker/metrics package and MUST
+// use identical boundaries — SigNoz merges the two streams, and quantiles
+// over mixed bucket layouts are garbage.
+var GoodputBucketBoundaries = []float64{
+	1, 3, 10, 30, 100, 300,
+	1_000, 3_000, 10_000, 30_000, 100_000, 300_000,
+	1_000_000, 3_000_000, 10_000_000,
+}
+
 // Note - we don't use package-level init() because we want to defer initialization of
 // OTEL metrics until after we've configured the global meter provider.
 func Initialize() error {
@@ -114,7 +137,8 @@ func initialize() error {
 	// "bytes" spelling for consistency within this package's metrics.
 	if SessionGoodput, err = meter.Float64Histogram("proxy.session.goodput",
 		metric.WithUnit("bytes/s"),
-		metric.WithDescription("Per-session goodput: received (client->proxy) bytes per second of connection lifetime")); err != nil {
+		metric.WithDescription("Per-session goodput: received (client->proxy) bytes per second of connection lifetime"),
+		metric.WithExplicitBucketBoundaries(GoodputBucketBoundaries...)); err != nil {
 		return err
 	}
 

--- a/instrument/otelinstrument/otelinstrument.go
+++ b/instrument/otelinstrument/otelinstrument.go
@@ -39,7 +39,7 @@ var (
 	distinctClients                                          metric.Int64ObservableGauge
 )
 
-// GoodputBucketBoundaries are the explicit bucket boundaries, in bytes/s, for
+// goodputBucketBoundaries are the explicit bucket boundaries, in bytes/s, for
 // the proxy.session.goodput histogram: a half-decade log scale from 1 B/s to
 // 10 MB/s. Session goodput spans ~6 decades — idle keepalive sessions sit
 // below 100 B/s while real page loads run 100 kB/s–10 MB/s — and the SDK
@@ -56,7 +56,7 @@ var (
 // lantern-box emits the same metric from its tracker/metrics package and MUST
 // use identical boundaries — SigNoz merges the two streams, and quantiles
 // over mixed bucket layouts are garbage.
-var GoodputBucketBoundaries = []float64{
+var goodputBucketBoundaries = []float64{
 	1, 3, 10, 30, 100, 300,
 	1_000, 3_000, 10_000, 30_000, 100_000, 300_000,
 	1_000_000, 3_000_000, 10_000_000,
@@ -138,7 +138,7 @@ func initialize() error {
 	if SessionGoodput, err = meter.Float64Histogram("proxy.session.goodput",
 		metric.WithUnit("bytes/s"),
 		metric.WithDescription("Per-session goodput: received (client->proxy) bytes per second of connection lifetime"),
-		metric.WithExplicitBucketBoundaries(GoodputBucketBoundaries...)); err != nil {
+		metric.WithExplicitBucketBoundaries(goodputBucketBoundaries...)); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
## Problem

`proxy.session.goodput` is emitted with the OTel SDK **default** histogram boundaries: `[0, 5, 10, 25, 50, 75, 100, 250, 500, 750, 1000, 2500, 5000, 7500, 10000]`. The top boundary is 10,000 B/s, so every session faster than 10 kB/s — i.e. everything resembling real browsing speed — is censored into the final bucket. IR's daily p90 reads as exactly `10000` (the bucket edge, not a measurement). The metric currently supports no absolute "service quality" claim above 10 kB/s.

## Change

Explicit half-decade log-scale boundaries, 1 B/s → 10 MB/s:

```
1, 3, 10, 30, 100, 300, 1k, 3k, 10k, 30k, 100k, 300k, 1M, 3M, 10M
```

- Session goodput spans ~6 decades (idle keepalives < 100 B/s, page loads 100 kB/s–10 MB/s); a log scale gives every decade the same relative resolution, so p50/p90/p99 interpolate to meaningful values across the whole range.
- Added a test asserting the collected histogram datapoint carries these bounds (the SDK hint is honored end-to-end) and that a ~101 kB/s sample resolves above the old 10 kB/s ceiling.
- The same metric is emitted by both http-proxy (`instrument/otelinstrument`) and lantern-box (`tracker/metrics`); SigNoz merges the streams, so the boundary sets **must stay identical**. Sibling PR: getlantern/lantern-box#296

## SigNoz ingest cost delta: ~0 in steady state (by construction)

SigNoz bills per ingested sample. One goodput histogram datapoint per series per export interval stores as 20 samples: 16 `.bucket` (15 boundaries + overflow), plus `.count`/`.sum`/`.min`/`.max`. Per lantern-cloud #3069's measurements this family is ~20% of total metric ingest (`.bucket`+`.count` 17%, `.min/.max/.sum` 3% — exactly the 17:3 sample ratio, which confirms the model).

- **This change keeps exactly 15 boundaries — the SDK default's count — so per-export sample volume is unchanged: delta ≈ 0.** #3069 existed to fix SigNoz 429 rate-limiting; its headroom is preserved.
- A finer 1-2-5 log scale (22 boundaries) was considered and rejected: it would grow `.bucket` samples by ~44% ≈ +7pp of total metric ingest.
- **Transient during the fleet roll:** the `le` label values change, so new series appear while unrolled proxies still emit the old layout — a temporary ≤2× series-cardinality bump on this family with **no** extra samples per proxy (each proxy emits exactly one layout). Old series go stale as the roll completes (~1–2 days via the autorelease poller + hot-swap).

## Reading the metric across the roll

- Absolute per-track/country medians will step when a route rolls: the interpolation grid in the busiest region changed (100/250/500/750/1000 → 100/300/1000). Challenger and control shift together, so evaluator *relative* verdicts stay sound, but avoid comparing absolute p50s across the roll boundary.
- Quantiles computed over a window mixing both layouts are unreliable for that window; per-country daily p90s are trustworthy again once the roll finishes.

Context: `proxy.session.goodput` clips + `.sum` gotchas in the 2026-08-05 bandit handoff; lantern-cloud PR documenting the family's readers: getlantern/lantern-cloud#3114


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved session goodput measurement with explicit histogram ranges spanning 1 B/s to 10 MB/s.
  * Goodput values are now grouped into predictable buckets for more consistent monitoring and analysis.

* **Tests**
  * Added coverage verifying bucket placement for approximately 101 kB/s session goodput values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->