### PR TITLE
metrics: export histograms with delta temporality

### DIFF
--- a/otel/otel.go
+++ b/otel/otel.go
@@ -171,18 +171,7 @@ func BuildTracerProvider(opts *Opts) (*sdktrace.TracerProvider, func()) {
 func InitGlobalMeterProvider(opts *Opts) (func(), error) {
 	logExporterEndpoint("metrics")
 	exp, err := otlpmetrichttp.New(context.Background(),
-		otlpmetrichttp.WithTemporalitySelector(func(kind sdkmetric.InstrumentKind) metricdata.Temporality {
-			switch kind {
-			case
-				sdkmetric.InstrumentKindCounter,
-				sdkmetric.InstrumentKindUpDownCounter,
-				sdkmetric.InstrumentKindObservableCounter,
-				sdkmetric.InstrumentKindObservableUpDownCounter:
-				return metricdata.DeltaTemporality
-			default:
-				return metricdata.CumulativeTemporality
-			}
-		}),
+		otlpmetrichttp.WithTemporalitySelector(deltaTemporality),
 	)
 	if err != nil {
 		return nil, err
@@ -201,4 +190,25 @@ func InitGlobalMeterProvider(opts *Opts) (func(), error) {
 			log.Errorf("error shutting down meter provider: %v", err)
 		}
 	}, nil
+}
+
+// deltaTemporality exports every instrument kind with delta temporality,
+// including histograms.
+//
+// Delta is what lets the ops collector aggregate an attribute away. Stripping
+// a label from a cumulative stream merges independent monotonic series whose
+// resets are interleaved, which corrupts rate() silently rather than failing;
+// delta datapoints just sum. The ops collector relies on this to drop
+// route.id/instance.id/host.name from proxy.session.goodput, whose ~10.8k
+// distinct host.name values were driving the histogram to ~55M series (see
+// getlantern/engineering#3831).
+//
+// Temporality is chosen per instrument KIND at the exporter, so this covers
+// every histogram this binary emits, not just goodput. The only other one with
+// readers is proxy_http_ping_request_duration_seconds, read as a p90 over
+// .bucket by the host_metrics and track_performance_by_volume dashboards; a
+// bucket quantile is computed over per-bucket rates and reads correctly on
+// either temporality.
+func deltaTemporality(sdkmetric.InstrumentKind) metricdata.Temporality {
+	return metricdata.DeltaTemporality
 }

--- a/otel/otel_test.go
+++ b/otel/otel_test.go
@@ -1,0 +1,36 @@
+package otel
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
+	"go.opentelemetry.io/otel/sdk/metric/metricdata"
+)
+
+// TestDeltaTemporalityCoversHistograms guards the exporter's temporality
+// selection.
+//
+// InstrumentKindHistogram is the one that matters: it was cumulative while
+// counters were already delta, and it is the kind proxy.session.goodput uses.
+// Delta is required for the ops collector to strip
+// route.id/instance.id/host.name from that metric — aggregating an identifier
+// away merges the matching series, and merging cumulative streams interleaves
+// their resets, corrupting rate() with no error. lantern-cloud also reads the
+// paired .count stream with timeAggregation=sum, which is only correct for
+// delta (increase vs sum on the wrong temporality is a ~500x error).
+func TestDeltaTemporalityCoversHistograms(t *testing.T) {
+	kinds := []sdkmetric.InstrumentKind{
+		sdkmetric.InstrumentKindCounter,
+		sdkmetric.InstrumentKindUpDownCounter,
+		sdkmetric.InstrumentKindHistogram,
+		sdkmetric.InstrumentKindGauge,
+		sdkmetric.InstrumentKindObservableCounter,
+		sdkmetric.InstrumentKindObservableUpDownCounter,
+		sdkmetric.InstrumentKindObservableGauge,
+	}
+	for _, k := range kinds {
+		assert.Equal(t, metricdata.DeltaTemporality, deltaTemporality(k),
+			"instrument kind %v must export delta", k)
+	}
+}


### PR DESCRIPTION
## What

Switch the OTLP metrics exporter to **delta** temporality for all instrument kinds, so histograms (notably `proxy.session.goodput`) are delta.

Part of getlantern/engineering#3831. Companion PRs: getlantern/lantern-box (same change), getlantern/lantern-cloud (collector + readers), getlantern/lantern-dashboard (query hint).

## Why

SigNoz reported `proxy.session.goodput.bucket` at **~55M unique time series**, timing out every query over a window of ~1 week or longer.

Measured cause, from `signoz_check_metric_cardinality` over 7d: `host.name` has **10,854** distinct values on this metric, with `route.id` and `instance.id` in the same range. Times 15 bucket boundaries × track × ~200 client countries.

**No reader anywhere uses those labels.** Audited org-wide (`gh search code --owner getlantern` plus every local clone):

| Repo | Reader | Groups by |
|---|---|---|
| lantern-cloud | `cmd/api/experiment/signoz.go` | `track`, `geo.country.iso_code` |
| lantern-dashboard | `ExperimentsOverview.tsx` | `track` (+ country filter) |

Plus 0 dashboards and 0 alerts. The identifiers exist only because the host tags every metric via `OTEL_RESOURCE_ATTRIBUTES` and SigNoz promotes resource attributes to queryable labels.

The fix is to aggregate them away in the ops collector, but that is **only safe on a delta stream**. Stripping a label from a cumulative stream merges independent monotonic series whose resets interleave, which corrupts `rate()` silently instead of failing. Hence delta here first.

## Scope note

Temporality is selected per instrument **kind** at the exporter, so this covers every histogram this binary emits, not just goodput. The only other one with readers is `proxy_http_ping_request_duration_seconds`, read as a p90 over `.bucket` by the `host_metrics` and `track_performance_by_volume` dashboards. A bucket quantile is computed over per-bucket rates and reads correctly on either temporality.

## Deploy ordering (important)

lantern-cloud switches the paired `.count` read from `increase` to `sum` to match delta. The two are **not** interchangeable: measured on RU over one day of still-cumulative data, `sum` returned **3.59e9** sessions where `increase` returned **7.0e6**, a ~500x overcount. An inflated count does not look like an outage; it silently clears every sample floor in the experiment evaluator and the impact ledger.

So:
1. Hold `experiment_evaluator_autoact_enabled` **off**.
2. Land this + lantern-box + lantern-cloud together; roll the fleet.
3. Confirm every host reports delta, then re-enable.

## Testing

- `go build ./otel/ ./instrument/...` and `go vet ./otel/` clean. (`go build ./...` fails on `go-libutp` cgo on main, unrelated.)
- Delta/strip behavior verified end to end against otelcol-contrib 0.146.0 with the real ops config: goodput loses `host.name`/`route.id`/`instance.id` while `proxy.io` and `system.cpu.utilization` keep them.

/cc @jay-418 @Crosse


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated metric export behavior to consistently use delta temporality across all metric instrument types.
  * Histogram metrics now follow the same delta-based reporting behavior as other instruments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->