### PR TITLE
build: bump lampshade to fix session desync that hung TestRoundTrip

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -23,7 +23,7 @@ require (
 	github.com/getlantern/idletiming v0.0.0-20200228204104-10036786eac5
 	github.com/getlantern/kcpwrapper v0.0.0-20230327091313-c12d7c17c6de
 	github.com/getlantern/keyman v0.0.0-20230503155501-4e864ca2175b
-	github.com/getlantern/lampshade v0.0.0-20260821105435-79296751c6d0
+	github.com/getlantern/lampshade v0.0.0-20260821140109-7c74457479f7
 	github.com/getlantern/lantern-algeneva v0.0.0-20240418193310-610690afddbc
 	github.com/getlantern/lantern-water v0.0.0-20241217184729-97b2bf6add4a
 	github.com/getlantern/measured v0.0.0-20230919230611-3d9e3776a6cd

--- a/go.mod
+++ b/go.mod
@@ -23,7 +23,7 @@ require (
 	github.com/getlantern/idletiming v0.0.0-20200228204104-10036786eac5
 	github.com/getlantern/kcpwrapper v0.0.0-20230327091313-c12d7c17c6de
 	github.com/getlantern/keyman v0.0.0-20230503155501-4e864ca2175b
-	github.com/getlantern/lampshade v0.0.0-20200303040944-fe53f13203e9
+	github.com/getlantern/lampshade v0.0.0-20260821104346-0863c5c50ba1
 	github.com/getlantern/lantern-algeneva v0.0.0-20240418193310-610690afddbc
 	github.com/getlantern/lantern-water v0.0.0-20241217184729-97b2bf6add4a
 	github.com/getlantern/measured v0.0.0-20230919230611-3d9e3776a6cd

--- a/go.mod
+++ b/go.mod
@@ -23,7 +23,7 @@ require (
 	github.com/getlantern/idletiming v0.0.0-20200228204104-10036786eac5
 	github.com/getlantern/kcpwrapper v0.0.0-20230327091313-c12d7c17c6de
 	github.com/getlantern/keyman v0.0.0-20230503155501-4e864ca2175b
-	github.com/getlantern/lampshade v0.0.0-20260821104346-0863c5c50ba1
+	github.com/getlantern/lampshade v0.0.0-20260821105435-79296751c6d0
 	github.com/getlantern/lantern-algeneva v0.0.0-20240418193310-610690afddbc
 	github.com/getlantern/lantern-water v0.0.0-20241217184729-97b2bf6add4a
 	github.com/getlantern/measured v0.0.0-20230919230611-3d9e3776a6cd

--- a/go.sum
+++ b/go.sum
@@ -281,8 +281,8 @@ github.com/getlantern/keepcurrent v0.0.0-20260616120552-f204338b01a3/go.mod h1:a
 github.com/getlantern/keyman v0.0.0-20180207174507-f55e7280e93a/go.mod h1:FMf0g72BHs14jVcD8i8ubEk4sMB6JdidBn67d44i3ws=
 github.com/getlantern/keyman v0.0.0-20230503155501-4e864ca2175b h1:iyEuk8ARQC9HfraqC4r3leBhU55R1TV7bAiyPYE54kA=
 github.com/getlantern/keyman v0.0.0-20230503155501-4e864ca2175b/go.mod h1:ZJ+yDaZkJ/JU9j7EQa3UUh6ouedrNDDLA5OiowS1Iuk=
-github.com/getlantern/lampshade v0.0.0-20260821105435-79296751c6d0 h1:iy5UU1fc1izoOd1OXz8VCk6OzBF7sD1v29XMEmnFBdg=
-github.com/getlantern/lampshade v0.0.0-20260821105435-79296751c6d0/go.mod h1:Zqiq4op+E689yjuJACMLURzE9XUGj48UDZP7h8aN+kk=
+github.com/getlantern/lampshade v0.0.0-20260821140109-7c74457479f7 h1:BA/09auzzo/60SMwoYEYxDL1hzLNVfbqAHnpbkIXfRI=
+github.com/getlantern/lampshade v0.0.0-20260821140109-7c74457479f7/go.mod h1:Zqiq4op+E689yjuJACMLURzE9XUGj48UDZP7h8aN+kk=
 github.com/getlantern/lantern-algeneva v0.0.0-20240418193310-610690afddbc h1:NlvxqmHvBr27TBzbxUsOFXtRtgW7FmoMkTTQhD6LXKU=
 github.com/getlantern/lantern-algeneva v0.0.0-20240418193310-610690afddbc/go.mod h1:bNnBc1YoooeKURbR6TMgNTuBA5ZjD28TSvZjbPUomVI=
 github.com/getlantern/lantern-water v0.0.0-20241217184729-97b2bf6add4a h1:3i8teo3y32raoP3g0crSwEVjeZvCxjoEIGVbtBhttIw=

--- a/go.sum
+++ b/go.sum
@@ -281,8 +281,8 @@ github.com/getlantern/keepcurrent v0.0.0-20260616120552-f204338b01a3/go.mod h1:a
 github.com/getlantern/keyman v0.0.0-20180207174507-f55e7280e93a/go.mod h1:FMf0g72BHs14jVcD8i8ubEk4sMB6JdidBn67d44i3ws=
 github.com/getlantern/keyman v0.0.0-20230503155501-4e864ca2175b h1:iyEuk8ARQC9HfraqC4r3leBhU55R1TV7bAiyPYE54kA=
 github.com/getlantern/keyman v0.0.0-20230503155501-4e864ca2175b/go.mod h1:ZJ+yDaZkJ/JU9j7EQa3UUh6ouedrNDDLA5OiowS1Iuk=
-github.com/getlantern/lampshade v0.0.0-20200303040944-fe53f13203e9 h1:n2t63QvweEs53Kpy7QbXv6JRSfXpDTTgPMT4cNTOt8g=
-github.com/getlantern/lampshade v0.0.0-20200303040944-fe53f13203e9/go.mod h1:Zqiq4op+E689yjuJACMLURzE9XUGj48UDZP7h8aN+kk=
+github.com/getlantern/lampshade v0.0.0-20260821104346-0863c5c50ba1 h1:bHG5ikpF2nHxfbwoGhPXV1W5mIaxZF3k8Wvjqc6BYS8=
+github.com/getlantern/lampshade v0.0.0-20260821104346-0863c5c50ba1/go.mod h1:Zqiq4op+E689yjuJACMLURzE9XUGj48UDZP7h8aN+kk=
 github.com/getlantern/lantern-algeneva v0.0.0-20240418193310-610690afddbc h1:NlvxqmHvBr27TBzbxUsOFXtRtgW7FmoMkTTQhD6LXKU=
 github.com/getlantern/lantern-algeneva v0.0.0-20240418193310-610690afddbc/go.mod h1:bNnBc1YoooeKURbR6TMgNTuBA5ZjD28TSvZjbPUomVI=
 github.com/getlantern/lantern-water v0.0.0-20241217184729-97b2bf6add4a h1:3i8teo3y32raoP3g0crSwEVjeZvCxjoEIGVbtBhttIw=

--- a/go.sum
+++ b/go.sum
@@ -281,8 +281,8 @@ github.com/getlantern/keepcurrent v0.0.0-20260616120552-f204338b01a3/go.mod h1:a
 github.com/getlantern/keyman v0.0.0-20180207174507-f55e7280e93a/go.mod h1:FMf0g72BHs14jVcD8i8ubEk4sMB6JdidBn67d44i3ws=
 github.com/getlantern/keyman v0.0.0-20230503155501-4e864ca2175b h1:iyEuk8ARQC9HfraqC4r3leBhU55R1TV7bAiyPYE54kA=
 github.com/getlantern/keyman v0.0.0-20230503155501-4e864ca2175b/go.mod h1:ZJ+yDaZkJ/JU9j7EQa3UUh6ouedrNDDLA5OiowS1Iuk=
-github.com/getlantern/lampshade v0.0.0-20260821104346-0863c5c50ba1 h1:bHG5ikpF2nHxfbwoGhPXV1W5mIaxZF3k8Wvjqc6BYS8=
-github.com/getlantern/lampshade v0.0.0-20260821104346-0863c5c50ba1/go.mod h1:Zqiq4op+E689yjuJACMLURzE9XUGj48UDZP7h8aN+kk=
+github.com/getlantern/lampshade v0.0.0-20260821105435-79296751c6d0 h1:iy5UU1fc1izoOd1OXz8VCk6OzBF7sD1v29XMEmnFBdg=
+github.com/getlantern/lampshade v0.0.0-20260821105435-79296751c6d0/go.mod h1:Zqiq4op+E689yjuJACMLURzE9XUGj48UDZP7h8aN+kk=
 github.com/getlantern/lantern-algeneva v0.0.0-20240418193310-610690afddbc h1:NlvxqmHvBr27TBzbxUsOFXtRtgW7FmoMkTTQhD6LXKU=
 github.com/getlantern/lantern-algeneva v0.0.0-20240418193310-610690afddbc/go.mod h1:bNnBc1YoooeKURbR6TMgNTuBA5ZjD28TSvZjbPUomVI=
 github.com/getlantern/lantern-water v0.0.0-20241217184729-97b2bf6add4a h1:3i8teo3y32raoP3g0crSwEVjeZvCxjoEIGVbtBhttIw=


### PR DESCRIPTION
## Problem

CI on main occasionally fails with `TestRoundTrip` hanging for the full 10-minute test timeout (e.g. [this run](https://github.com/getlantern/http-proxy/actions/runs/32471441943/job/96738885232)): 198/200 streams complete, one client goroutine stuck in `io.ReadFull` waiting for exactly one 1443-byte (`MaxDataLen`) frame, the matching server echo stuck waiting for more data, and every send/recv loop healthy and idle.

## Root cause

A frame-parsing bug in lampshade's `recvLoop`: an ACK frame arriving for an **already-closed stream** was skipped without consuming its 4-byte acked-frames payload. The parser then misread those zero bytes as a padding header and silently discarded every remaining frame coalesced in the same session frame — permanently stalling whichever live streams' frames followed. With `AckOnFirst: true` (which our `lampshade.Wrap` sets), the server sends an empty ACK for the first data frame of every inbound session frame, so any stream that writes and quickly closes leaves such a stale ACK in flight; under `TestRoundTrip`'s 100 concurrent streams on one session this occasionally kills a live stream's echo frame.

Fixed upstream in getlantern/lampshade#53 (with a regression test that reproduces the hang in ~15s before the fix). This PR bumps the dependency to that fix commit.

> Note: pinned to the commit on the PR branch. If lampshade#53 gets merged with a different SHA (e.g. squash), re-pin to the merged commit before/after merging this.

## Testing

- `go test ./lampshade/ -count=10 -race` passes against the fix (previously the flake).
- Upstream regression test fails pre-fix, passes post-fix (`-count=5`); full lampshade suite passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated an internal dependency to a newer version.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->